### PR TITLE
Add INT8 quantized model loading support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,10 +3189,12 @@ name = "wasm-pocket-tts"
 version = "0.1.0"
 dependencies = [
  "getrandom 0.3.4",
+ "half",
  "js-sys",
  "pocket_tts",
  "rand",
  "rand_distr",
+ "safetensors",
  "wasm-bindgen",
  "xn",
 ]

--- a/wasm-pocket-tts/Cargo.toml
+++ b/wasm-pocket-tts/Cargo.toml
@@ -14,6 +14,8 @@ js-sys = "0.3"
 rand = { version = "0.9", default-features = false, features = ["std_rng"] }
 rand_distr = "0.5"
 getrandom = { version = "0.3", features = ["wasm_js"] }
+half = "2"
+safetensors = "0.4"
 
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = false

--- a/wasm-pocket-tts/src/dequantize.rs
+++ b/wasm-pocket-tts/src/dequantize.rs
@@ -1,0 +1,116 @@
+//! INT8 → BF16 weight dequantization at load time.
+//!
+//! Reads a safetensors buffer that may contain INT8-quantized weight tensors
+//! (produced by `quantize.py`) alongside their per-channel BF16 scale factors.
+//! Dequantizes every I8 tensor back to BF16, then returns a clean safetensors
+//! buffer identical in dtype to the original non-quantized model.
+//!
+//! Convention produced by `quantize.py`:
+//!   - Quantized weight: same tensor name as original, stored as **I8**
+//!   - Scale factor:     `{name}_scale`, stored as **BF16**, shape `[out_channels]`
+//!
+//! Dequantization (per output channel `c`):
+//!   `bf16_weight[c, ..] = bf16(i8_weight[c, ..]) * bf16_scale[c]`
+
+use std::collections::HashSet;
+
+/// Check whether `buffer` contains any I8 tensors. If so, dequantize them to
+/// BF16 and return a new safetensors buffer. If the buffer is already fully
+/// float, return a copy without extra work.
+pub fn dequantize_if_needed(buffer: &[u8]) -> Vec<u8> {
+    let st = match safetensors::SafeTensors::deserialize(buffer) {
+        Ok(st) => st,
+        Err(_) => return buffer.to_vec(),
+    };
+
+    let has_i8 = st.iter().any(|(_, t)| t.dtype() == safetensors::Dtype::I8);
+    if !has_i8 {
+        return buffer.to_vec();
+    }
+
+    dequantize_inner(&st)
+}
+
+/// Perform the actual I8 → BF16 dequantization.
+fn dequantize_inner(st: &safetensors::SafeTensors<'_>) -> Vec<u8> {
+    let scale_names: HashSet<String> = st
+        .iter()
+        .filter(|(_, t)| t.dtype() == safetensors::Dtype::I8)
+        .map(|(name, _)| format!("{name}_scale"))
+        .collect();
+
+    let mut views: Vec<(String, OwnedView)> = Vec::new();
+
+    for (name, tensor) in st.iter() {
+        let name = name.to_string();
+
+        if scale_names.contains(&name) {
+            continue;
+        }
+
+        if tensor.dtype() == safetensors::Dtype::I8 {
+            let scale_name = format!("{name}_scale");
+            let scale_tensor = match st.tensor(&scale_name) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+
+            let shape = tensor.shape().to_vec();
+            let out_channels = shape[0];
+            let elements_per_channel: usize = shape[1..].iter().product();
+
+            // Read scale factors as little-endian bf16.
+            let scale_bytes = scale_tensor.data();
+            let scales: Vec<half::bf16> = scale_bytes
+                .chunks_exact(2)
+                .map(|c| half::bf16::from_le_bytes([c[0], c[1]]))
+                .collect();
+
+            // Dequantize: cast i8 to bf16, multiply by bf16 scale.
+            let i8_data = tensor.data();
+            let total = out_channels * elements_per_channel;
+            let mut bf16_bytes: Vec<u8> = Vec::with_capacity(total * 2);
+
+            for ch in 0..out_channels {
+                let s = scales[ch];
+                let base = ch * elements_per_channel;
+                for i in 0..elements_per_channel {
+                    let q = i8_data[base + i] as i8;
+                    let val = half::bf16::from_f32(q as f32) * s;
+                    bf16_bytes.extend_from_slice(&val.to_le_bytes());
+                }
+            }
+
+            views.push((name, OwnedView {
+                data: bf16_bytes,
+                shape,
+                dtype: safetensors::Dtype::BF16,
+            }));
+        } else {
+            views.push((name, OwnedView {
+                data: tensor.data().to_vec(),
+                shape: tensor.shape().to_vec(),
+                dtype: tensor.dtype(),
+            }));
+        }
+    }
+
+    let view_refs: Vec<(&str, safetensors::tensor::TensorView<'_>)> = views
+        .iter()
+        .map(|(name, v)| {
+            (
+                name.as_str(),
+                safetensors::tensor::TensorView::new(v.dtype, v.shape.clone(), &v.data)
+                    .expect("invalid tensor view"),
+            )
+        })
+        .collect();
+
+    safetensors::tensor::serialize(view_refs, &None).expect("serialization failed")
+}
+
+struct OwnedView {
+    data: Vec<u8>,
+    shape: Vec<usize>,
+    dtype: safetensors::Dtype,
+}

--- a/wasm-pocket-tts/src/lib.rs
+++ b/wasm-pocket-tts/src/lib.rs
@@ -1,3 +1,5 @@
+mod dequantize;
+
 use std::sync::Mutex;
 use wasm_bindgen::prelude::*;
 
@@ -176,7 +178,8 @@ impl Model {
     pub fn new_(model_weights: &[u8]) -> xn::Result<Model> {
         let cfg = TTSConfig::v202601(0.7);
 
-        let vb = VB::from_bytes_with_key_map(vec![model_weights.to_vec()], CPU, remap_key)?;
+        let model_bytes = dequantize::dequantize_if_needed(model_weights);
+        let vb = VB::from_bytes_with_key_map(vec![model_bytes], CPU, remap_key)?;
         let root = vb.root();
         let tokenizer = std::sync::Arc::new(PresetTokenizer::new());
         let tokenizer_box: Box<dyn pocket_tts::Tokenizer + Send + Sync> =

--- a/wasm-pocket-tts/www/index.html
+++ b/wasm-pocket-tts/www/index.html
@@ -53,6 +53,9 @@
       <option value="azelma">Azelma</option>
     </select>
   </div>
+  <label style="display:flex;align-items:center;gap:4px;font-weight:400;cursor:pointer">
+    <input type="checkbox" id="quantized"> INT8
+  </label>
   <button id="load-btn">Load Weights (240MB)</button>
   <button id="generate-btn" style="display:none">Generate</button>
   <div class="slider-section">
@@ -77,9 +80,16 @@ const canvas = document.getElementById('visualizer');
 const canvasCtx = canvas.getContext('2d');
 const tempSlider = document.getElementById('temperature');
 const tempValue = document.getElementById('temp-value');
+const quantizedCb = document.getElementById('quantized');
 
 tempSlider.addEventListener('input', () => {
   tempValue.textContent = tempSlider.value;
+});
+
+quantizedCb.addEventListener('change', () => {
+  loadBtn.textContent = quantizedCb.checked
+    ? 'Load Weights (139MB, INT8)'
+    : 'Load Weights (240MB)';
 });
 
 function log(msg) {
@@ -313,7 +323,8 @@ function concatenateChunks(chunks) {
 
 function loadWeights() {
   loadBtn.disabled = true;
-  worker.postMessage({ type: 'load', voiceName: voiceSelect.value });
+  quantizedCb.disabled = true;
+  worker.postMessage({ type: 'load', voiceName: voiceSelect.value, quantized: quantizedCb.checked });
 }
 
 function generate() {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                   
                                                                                                                                                                                                               
  - Add transparent INT8 → BF16 dequantization at model load time in `wasm-pocket-tts`, so quantized safetensors files (produced by per-channel INT8 quantization with companion `_scale` tensors) are
  converted back to BF16 before being fed to the model. Non-quantized models pass through unchanged.
  - Add an INT8 checkbox to the web demo, letting users choose between the full BF16 model (240MB) and the INT8 quantized model (139MB, hosted at
  [idle-intelligence/pocket-tts-int8](https://huggingface.co/idle-intelligence/pocket-tts-int8)).

  ## Changes

  1. **`wasm-pocket-tts/src/dequantize.rs`** — new module: detects I8 tensors in a safetensors buffer, reads their `{name}_scale` BF16 counterparts, dequantizes per output channel, and re-serializes a clean
  BF16 buffer.
  2. **`wasm-pocket-tts/src/lib.rs`** — call `dequantize_if_needed()` on the raw weight bytes before loading into `VarBuilder`.
  3. **`wasm-pocket-tts/Cargo.toml`** — add `half` and `safetensors` dependencies.
  4. **`wasm-pocket-tts/www/worker.js`** — add HF URL for the INT8 model, select model URL based on a `quantized` flag.
  5. **`wasm-pocket-tts/www/index.html`** — add INT8 checkbox, update button label dynamically.

  ## Test plan

  - [x] Tested locally: load with INT8 unchecked (full model) — works as before
  - [x] Tested locally: load with INT8 checked (quantized model) — dequantizes and generates audio correctly