### PR TITLE
Vectorize the Vulkan GEMV weight-row loads

### DIFF
--- a/xn-core/src/vulkan_backend/backend_impl.rs
+++ b/xn-core/src/vulkan_backend/backend_impl.rs
@@ -482,11 +482,14 @@ impl crate::Backend for Device {
             .usize(dst_cs)
             .usize(lhs.1)
             .usize(rhs.1);
-        let buffers = [dst.buffer, lhs.0.buffer, rhs.0.buffer];
         if m == 1 {
             // Decode path: one workgroup per output column, grid (n, batch, 1).
+            // rhs is bound twice: once scalar, once as a vec4 view for the
+            // shader's aligned-fast-path loads (see gemv.comp).
+            let buffers = [dst.buffer, lhs.0.buffer, rhs.0.buffer, rhs.0.buffer];
             dst.device.dispatch_nd(&format!("gemv_{dt}"), &buffers, &push, (n as u32, lhs_b as u32, 1))
         } else {
+            let buffers = [dst.buffer, lhs.0.buffer, rhs.0.buffer];
             // Tiled kernel: grid (ceil(n/16), ceil(m/16), batch), local (16, 16, 1).
             const TILE: u32 = 16;
             let groups = (div_ceil(n, TILE), div_ceil(m, TILE), lhs_b as u32);

--- a/xn-core/src/vulkan_backend/mod.rs
+++ b/xn-core/src/vulkan_backend/mod.rs
@@ -92,7 +92,7 @@ fn kernel_def(name: &str) -> Option<(&'static [u8], u32)> {
         }
         "scatter_set" => (SCATTER_SET_F32, Some(SCATTER_SET_F16), Some(SCATTER_SET_BF16), 3),
         "gemm_tiled" => (GEMM_TILED_F32, Some(GEMM_TILED_F16), Some(GEMM_TILED_BF16), 3),
-        "gemv" => (GEMV_F32, Some(GEMV_F16), Some(GEMV_BF16), 3),
+        "gemv" => (GEMV_F32, Some(GEMV_F16), Some(GEMV_BF16), 4),
         // conv shaders are f32-only; other dtypes must fail pipeline lookup.
         "conv1d" => (CONV1D_F32, None, None, 3),
         "conv_transpose1d" => (CONV_TRANSPOSE1D_F32, None, None, 3),

--- a/xn-core/vulkan-kernels/gemv.comp
+++ b/xn-core/vulkan-kernels/gemv.comp
@@ -12,12 +12,43 @@
 // bandwidth-bound GEMV needs on this APU. Alternatives that compute several
 // columns per workgroup (llama.cpp's mul_mat_vec style) reduce the workgroup
 // count and measured slower here.
+//
+// `rhs` (the dominant, bandwidth-bound stream) is bound a second time as a
+// 4-wide vector view (`rhs4`, binding 3, same underlying buffer) so that when
+// the row is 4-element-aligned we can issue one 64/128-bit load per thread
+// instead of four scalar loads, quartering instruction count without
+// touching the coalescing pattern above. `lhs` stays scalar: it is a single
+// tiny row re-read by every workgroup, so it lives in cache and isn't worth
+// vectorizing. Any k % 4 remainder falls back to the scalar `rhs` binding, and
+// the whole fast path is skipped (falls back to the original scalar loop)
+// whenever the row start isn't 4-aligned (e.g. sliced/viewed tensors).
 // Grid: (n, batch, 1). Push constants match the GEMM kernels.
 layout(local_size_x = 256) in;
+
+#ifdef USE_F16
+#define SCALAR4 f16vec4
+#define LOAD4_0(v) float((v).x)
+#define LOAD4_1(v) float((v).y)
+#define LOAD4_2(v) float((v).z)
+#define LOAD4_3(v) float((v).w)
+#elif defined(USE_BF16)
+#define SCALAR4 u16vec4
+#define LOAD4_0(v) bf16_load((v).x)
+#define LOAD4_1(v) bf16_load((v).y)
+#define LOAD4_2(v) bf16_load((v).z)
+#define LOAD4_3(v) bf16_load((v).w)
+#else
+#define SCALAR4 vec4
+#define LOAD4_0(v) ((v).x)
+#define LOAD4_1(v) ((v).y)
+#define LOAD4_2(v) ((v).z)
+#define LOAD4_3(v) ((v).w)
+#endif
 
 layout(std430, set = 0, binding = 0) buffer D { SCALAR dst[]; };
 layout(std430, set = 0, binding = 1) buffer L { SCALAR lhs[]; };
 layout(std430, set = 0, binding = 2) buffer R { SCALAR rhs[]; };
+layout(std430, set = 0, binding = 3) buffer R4 { SCALAR4 rhs4[]; };
 
 layout(push_constant) uniform PC {
     uint m;
@@ -47,8 +78,25 @@ void main() {
     uint rbase = pc.rhs_o + b * pc.rhs_b_stride + j * pc.rhs_cs;
 
     float acc = 0.0;
-    for (uint l = tid; l < pc.k; l += 256u) {
-        acc += LOAD(lhs[lbase + l * pc.lhs_cs]) * LOAD(rhs[rbase + l * pc.rhs_rs]);
+    if (pc.rhs_rs == 1u && pc.k >= 4u && (rbase & 3u) == 0u) {
+        uint k4 = pc.k >> 2u;
+        uint kbulk = k4 << 2u;
+        uint base4 = rbase >> 2u;
+        for (uint g = tid; g < k4; g += 256u) {
+            SCALAR4 rv = rhs4[base4 + g];
+            uint l = g * 4u;
+            acc += LOAD4_0(rv) * LOAD(lhs[lbase + (l + 0u) * pc.lhs_cs]);
+            acc += LOAD4_1(rv) * LOAD(lhs[lbase + (l + 1u) * pc.lhs_cs]);
+            acc += LOAD4_2(rv) * LOAD(lhs[lbase + (l + 2u) * pc.lhs_cs]);
+            acc += LOAD4_3(rv) * LOAD(lhs[lbase + (l + 3u) * pc.lhs_cs]);
+        }
+        for (uint l = kbulk + tid; l < pc.k; l += 256u) {
+            acc += LOAD(lhs[lbase + l * pc.lhs_cs]) * LOAD(rhs[rbase + l]);
+        }
+    } else {
+        for (uint l = tid; l < pc.k; l += 256u) {
+            acc += LOAD(lhs[lbase + l * pc.lhs_cs]) * LOAD(rhs[rbase + l * pc.rhs_rs]);
+        }
     }
     sh[tid] = acc;
     barrier();


### PR DESCRIPTION
## Summary
- `gemv.comp` binds `rhs` a second time as a 4-wide vector view (`vec4`/`f16vec4`/`u16vec4` depending on dtype), so each thread issues one 64/128-bit load instead of four scalar loads for the dominant, bandwidth-bound weight stream in the decode-time GEMV kernel.
- Gated by a **runtime** check (`rhs_rs == 1 && k >= 4 && row-start 4-aligned`), with a scalar tail for any `k % 4` remainder and a full scalar fallback otherwise (e.g. the attn·V gemv, where `rhs_rs != 1`) — no compile-time assumption about tensor offsets/strides.
- `lhs` stays scalar (tiny, cache-resident row); this only widens the load for the weight matrix.

## Measurements
Moshi ASR benchmark (`kyutai/stt-2.6b`, 44.85s audio clip):
- Wall time: 29.92s → 26.6s (1.6x → 1.8x realtime, ~11% faster)
- `gemv_bf16` kernel total: 18.64s → 16.01s (93.1µs vs 108.4µs avg per dispatch)
- Effective bandwidth: ~194 GB/s → ~226 GB/s (~88% of the 256 GB/s theoretical peak on this APU, up from ~75%)
- Transcript output byte-identical before/after

## Test plan
- [x] `cargo test --no-default-features --features vulkan --test vulkan_tests --release` (42/42 pass)
- [x] `cargo test --no-default-features --features vulkan --test tensor_tests --release vulkan` (102/102 pass)
- [x] `cargo clippy --release --no-default-features --features vulkan -p xn` clean
- [x] Manual ASR run, transcript compared byte-for-byte against baseline

https://claude.ai/code/session_01QmiSVGYBiB9DaQ3r8p9QGJ