### PR TITLE
Vulkan conv1d/conv_transpose1d: im2col/col2im + GEMM

### DIFF
--- a/xn-core/src/vulkan_backend/backend_impl.rs
+++ b/xn-core/src/vulkan_backend/backend_impl.rs
@@ -808,6 +808,22 @@ impl crate::Backend for Device {
         groups: usize,
     ) -> Result<()> {
         check_f32::<T>("conv1d")?;
+        if groups == 1 {
+            return conv1d_im2col(
+                dst,
+                src,
+                kernel,
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+            );
+        }
         let total = batch * out_channels * out_length;
         let push = Pc::new()
             .usize(batch)
@@ -840,10 +856,26 @@ impl crate::Backend for Device {
         kernel_size: usize,
         stride: usize,
         padding: usize,
-        _output_padding: usize,
+        output_padding: usize,
         groups: usize,
     ) -> Result<()> {
         check_f32::<T>("conv_transpose1d")?;
+        // col2im assumes groups == 1, no padding/output_padding and (per the
+        // Backend trait, which has no dilation param here) dilation == 1.
+        if groups == 1 && padding == 0 && output_padding == 0 {
+            return conv_transpose1d_col2im(
+                dst,
+                src,
+                kernel,
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+            );
+        }
         let total = batch * out_channels * out_length;
         let push = Pc::new()
             .usize(batch)
@@ -862,6 +894,122 @@ impl crate::Backend for Device {
             div_ceil(total, WORKGROUP_SIZE),
         )
     }
+}
+
+/// `groups == 1` conv1d via im2col + GEMM + transpose (mirrors the CUDA
+/// backend): unfold `src` into `col` [batch, out_length, in_channels*kernel_size],
+/// multiply by the [out_channels, in_channels*kernel_size] weight matrix
+/// (matmul_t), then transpose the [batch, out_length, out_channels] GEMM
+/// result into dst's [batch, out_channels, out_length] layout. This trades
+/// conv1d's naive per-output-element gather loop for the same tiled/vectorized
+/// GEMM path used everywhere else, at the cost of the `col` scratch buffer.
+#[allow(clippy::too_many_arguments)]
+fn conv1d_im2col<T: WithDTypeF>(
+    dst: &mut Storage<T>,
+    src: &Storage<T>,
+    kernel: &Storage<T>,
+    batch: usize,
+    in_channels: usize,
+    out_channels: usize,
+    length: usize,
+    out_length: usize,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+) -> Result<()> {
+    let dev = dst.device.clone();
+    let k = in_channels * kernel_size;
+
+    let col = unsafe { <Device as crate::Backend>::alloc_uninit::<T>(batch * out_length * k, &dev)? };
+    let push = Pc::new()
+        .usize(batch)
+        .usize(in_channels)
+        .usize(length)
+        .usize(out_length)
+        .usize(kernel_size)
+        .usize(stride)
+        .usize(padding)
+        .usize(dilation);
+    dev.dispatch(
+        "im2col1d_f32",
+        &[col.buffer, src.buffer],
+        &push,
+        div_ceil(batch * out_length * k, WORKGROUP_SIZE),
+    )?;
+
+    // result[b, l, oc] = sum_k col[b, l, k] * kernel[oc, k]
+    let mut result = unsafe { <Device as crate::Backend>::alloc_uninit::<T>(batch * out_length * out_channels, &dev)? };
+    <Device as crate::Backend>::gemm(
+        &mut result,
+        (&col, 0),
+        (kernel, 0),
+        out_length,
+        out_channels,
+        k,
+        batch,
+        out_length * k,
+        0,
+        (1, out_channels),
+        (1, k),
+        (k, 1),
+    )?;
+
+    // [batch, out_length, out_channels] -> dst's [batch, out_channels, out_length].
+    <Device as crate::Backend>::transpose(dst, &result, 1, 2, &[batch, out_length, out_channels])
+}
+
+/// `groups == 1`, no padding/output_padding conv_transpose1d via transpose +
+/// GEMM + col2im (mirrors the CUDA backend): transpose `src` to
+/// [batch, length, in_channels], multiply by the [in_channels, out_channels*kernel_size]
+/// weight matrix to get `col` [batch, length, out_channels*kernel_size], then
+/// fold `col` into dst via col2im's gather (each output position sums the
+/// compatible (input position, kernel offset) pairs directly, no atomics).
+#[allow(clippy::too_many_arguments)]
+fn conv_transpose1d_col2im<T: WithDTypeF>(
+    dst: &mut Storage<T>,
+    src: &Storage<T>,
+    kernel: &Storage<T>,
+    batch: usize,
+    in_channels: usize,
+    out_channels: usize,
+    length: usize,
+    out_length: usize,
+    kernel_size: usize,
+    stride: usize,
+) -> Result<()> {
+    let dev = dst.device.clone();
+    let n = out_channels * kernel_size;
+
+    let mut src_t = unsafe { <Device as crate::Backend>::alloc_uninit::<T>(batch * length * in_channels, &dev)? };
+    <Device as crate::Backend>::transpose(&mut src_t, src, 1, 2, &[batch, in_channels, length])?;
+
+    // col[b, l, j] = sum_c src_t[b, l, c] * kernel[c, j]
+    let mut col = unsafe { <Device as crate::Backend>::alloc_uninit::<T>(batch * length * n, &dev)? };
+    <Device as crate::Backend>::gemm(
+        &mut col,
+        (&src_t, 0),
+        (kernel, 0),
+        length,
+        n,
+        in_channels,
+        batch,
+        length * in_channels,
+        0,
+        (1, n),
+        (1, in_channels),
+        (1, n),
+    )?;
+
+    let push = Pc::new()
+        .usize(batch)
+        .usize(length)
+        .usize(out_channels)
+        .usize(out_length)
+        .usize(kernel_size)
+        .usize(stride);
+    let total = batch * out_channels * out_length;
+    dev.dispatch("col2im1d_f32", &[dst.buffer, col.buffer], &push, div_ceil(total, WORKGROUP_SIZE))
 }
 
 impl Device {

--- a/xn-core/src/vulkan_backend/mod.rs
+++ b/xn-core/src/vulkan_backend/mod.rs
@@ -96,6 +96,8 @@ fn kernel_def(name: &str) -> Option<(&'static [u8], u32)> {
         // conv shaders are f32-only; other dtypes must fail pipeline lookup.
         "conv1d" => (CONV1D_F32, None, None, 3),
         "conv_transpose1d" => (CONV_TRANSPOSE1D_F32, None, None, 3),
+        "im2col1d" => (IM2COL1D_F32, None, None, 2),
+        "col2im1d" => (COL2IM1D_F32, None, None, 2),
         _ => return None,
     };
     let bytes = match dt {

--- a/xn-core/tests/vulkan_tests.rs
+++ b/xn-core/tests/vulkan_tests.rs
@@ -476,6 +476,21 @@ fn cmp_conv1d(
     padding: usize,
     groups: usize,
 ) -> Result<()> {
+    cmp_conv1d_dilated(batch, in_c, out_c, len, ks, stride, padding, 1, groups)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cmp_conv1d_dilated(
+    batch: usize,
+    in_c: usize,
+    out_c: usize,
+    len: usize,
+    ks: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+    groups: usize,
+) -> Result<()> {
     let src = iota(batch * in_c * len);
     let kern = iota(out_c * (in_c / groups) * ks);
     let sv: Tensor<f32, Vk> = Tensor::from_vec(src.clone(), vec![batch, in_c, len], &dev())?;
@@ -483,8 +498,8 @@ fn cmp_conv1d(
         Tensor::from_vec(kern.clone(), vec![out_c, in_c / groups, ks], &dev())?;
     let sc: Tensor<f32, _> = Tensor::from_vec(src, vec![batch, in_c, len], &CPU)?;
     let kc: Tensor<f32, _> = Tensor::from_vec(kern, vec![out_c, in_c / groups, ks], &CPU)?;
-    let rc = sc.conv1d(&kc, None, stride, padding, 1, groups)?;
-    let rv = sv.conv1d(&kv, None, stride, padding, 1, groups)?;
+    let rc = sc.conv1d(&kc, None, stride, padding, dilation, groups)?;
+    let rv = sv.conv1d(&kv, None, stride, padding, dilation, groups)?;
     assert_close(&rc.to_vec()?, &rv.to_vec()?, 1e-4);
     Ok(())
 }
@@ -496,6 +511,10 @@ fn conv1d_cmp() -> Result<()> {
     cmp_conv1d(1, 1, 1, 6, 3, 2, 0, 1)?;
     cmp_conv1d(2, 3, 4, 7, 3, 1, 1, 1)?;
     cmp_conv1d(1, 4, 4, 7, 3, 1, 1, 2)?;
+    // Dilated, groups == 1 (the im2col fast path): matches Mimi's SEANet
+    // residual blocks, which use dilation > 1 with groups == 1.
+    cmp_conv1d_dilated(2, 3, 4, 20, 3, 1, 2, 3, 1)?;
+    cmp_conv1d_dilated(1, 2, 2, 25, 3, 1, 9, 9, 1)?;
     Ok(())
 }
 

--- a/xn-core/vulkan-kernels/col2im1d.comp
+++ b/xn-core/vulkan-kernels/col2im1d.comp
@@ -1,0 +1,50 @@
+#version 450
+// Col2Im for 1D transposed convolution (f32), gather form. Only used for the
+// groups == 1, padding == 0, output_padding == 0, dilation == 1 case (see
+// `can_use_col2im` on the Rust side); the general case still uses the direct
+// conv_transpose1d kernel.
+//   src (col): [batch, l_in, out_channels, kernel_size]
+//   dst: [batch, out_channels, out_length]
+// One thread per output element; dst is written in its natural flat order so
+// gid doubles as the destination index directly.
+layout(local_size_x = 256) in;
+
+layout(std430, set = 0, binding = 0) buffer D { float dst[]; };
+layout(std430, set = 0, binding = 1) buffer S { float src[]; };
+
+layout(push_constant) uniform PC {
+    uint batch;
+    uint l_in;
+    uint out_channels;
+    uint out_length;
+    uint kernel_size;
+    uint stride;
+} pc;
+
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    uint total = pc.batch * pc.out_channels * pc.out_length;
+    if (gid >= total) return;
+
+    uint l_out_idx = gid % pc.out_length;
+    uint tmp = gid / pc.out_length;
+    uint c_idx = tmp % pc.out_channels;
+    uint b = tmp / pc.out_channels;
+
+    uint src_s1 = pc.out_channels * pc.kernel_size;
+    uint src_batch_base = b * pc.l_in * src_s1;
+
+    // out_l = in_l * stride + k  =>  in_l = (out_l - k) / stride for k in
+    // [0, stride) so that the numerator is non-negative and divisible.
+    int l_in_idx = int(l_out_idx / pc.stride);
+    int k = int(l_out_idx) - l_in_idx * int(pc.stride);
+
+    float sum = 0.0;
+    for (; k < int(pc.kernel_size) && l_in_idx >= 0; k += int(pc.stride), l_in_idx -= 1) {
+        if (l_in_idx < int(pc.l_in)) {
+            uint src_idx = src_batch_base + uint(l_in_idx) * src_s1 + c_idx * pc.kernel_size + uint(k);
+            sum += src[src_idx];
+        }
+    }
+    dst[gid] = sum;
+}

--- a/xn-core/vulkan-kernels/im2col1d.comp
+++ b/xn-core/vulkan-kernels/im2col1d.comp
@@ -1,0 +1,44 @@
+#version 450
+// Im2Col for 1D convolution (f32), groups == 1 only.
+//   src: [batch, in_channels, in_len]
+//   dst (col): [batch, out_length, in_channels * kernel_size]
+// One thread per output element; dst is written in its natural flat order so
+// gid doubles as the destination index directly.
+layout(local_size_x = 256) in;
+
+layout(std430, set = 0, binding = 0) buffer D { float dst[]; };
+layout(std430, set = 0, binding = 1) buffer S { float src[]; };
+
+layout(push_constant) uniform PC {
+    uint batch;
+    uint in_channels;
+    uint in_len;
+    uint out_length;
+    uint kernel_size;
+    uint stride;
+    uint padding;
+    uint dilation;
+} pc;
+
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    uint ck = pc.in_channels * pc.kernel_size;
+    uint total = pc.batch * pc.out_length * ck;
+    if (gid >= total) return;
+
+    uint ck_idx = gid % ck;
+    uint tmp = gid / ck;
+    uint l = tmp % pc.out_length;
+    uint b = tmp / pc.out_length;
+
+    uint k_idx = ck_idx % pc.kernel_size;
+    uint c_idx = ck_idx / pc.kernel_size;
+
+    uint src_l_raw = l * pc.stride + k_idx * pc.dilation;
+    float v = 0.0;
+    if (src_l_raw >= pc.padding && src_l_raw < pc.padding + pc.in_len) {
+        uint src_l = src_l_raw - pc.padding;
+        v = src[(b * pc.in_channels + c_idx) * pc.in_len + src_l];
+    }
+    dst[gid] = v;
+}


### PR DESCRIPTION
## Summary
Prototypes the same im2col/col2im approach the CUDA backend already uses (`cuda-kernels/conv.cu`) for the Vulkan backend's `conv1d`/`conv_transpose1d`, replacing the naive per-output-element gather kernel with unfold + the existing generic GEMM dispatch (which gets tiling/vectorization for free, including the vec4 GEMV load from #39) + fold-back:

- `conv1d` (groups == 1): `im2col1d.comp` unfolds `src` into `col` [batch, out_length, in_channels*kernel_size], then a matmul_t-style GEMM against the `[out_channels, in_channels*kernel_size]` weight, then a transpose into dst's `[batch, out_channels, out_length]` layout.
- `conv_transpose1d` (groups == 1, padding == 0, output_padding == 0): transpose `src` to `[batch, length, in_channels]`, GEMM against `[in_channels, out_channels*kernel_size]`, then `col2im1d.comp` gathers (no atomics) into dst.
- Both fall back to the existing direct gather kernels outside those conditions. In practice every conv call site in Mimi's SEANet encoder/decoder has `groups == 1` (and the transposed convs there also have `padding == 0`, `output_padding == 0`), so this covers the real workload, not just an edge case — confirmed by grepping every `Conv1d::load`/`ConvTranspose1d::load` call site in `xn-core/src/models/mimi.rs`.

New shaders are f32-only, matching the existing `conv1d.comp`/`conv_transpose1d.comp` scope (Mimi always runs f32 regardless of the LM's dtype).

Rebased on `main` now that #39 is merged, so this diff is purely the im2col/col2im change.

## Measurements
Moshi ASR benchmark (`kyutai/stt-2.6b`, 44.85s clip), `main` (with #39) vs. this branch:
- Wall time: 26.75s → 23.2-23.64s (1.8x → 2.0x realtime, ~12% faster on top of #39)
- `conv1d_f32`'s 3.67s replaced by ~0.78s of `im2col1d_f32` + extra `gemm_tiled_f32` + `transpose_f32`
- Transcript byte-identical

Cumulative vs. the original pre-#39 baseline: 29.92s → ~23.4s (1.6x → 2.0x realtime, ~22% faster overall).

## Test plan
- [x] `cargo test --no-default-features --features vulkan --test vulkan_tests --release` (42/42 pass), including 2 new dilated `groups == 1` conv1d cases exercising Mimi's dilated residual blocks (the existing suite only covered `dilation == 1`)
- [x] `cargo test --no-default-features --features vulkan --test tensor_tests --release vulkan` (102/102 pass)
- [x] `cargo clippy --release --no-default-features --features vulkan -p xn` clean
- [x] Manual ASR run (2x), transcript compared byte-for-byte against baseline

https://claude.ai/code/session_01QmiSVGYBiB9DaQ3r8p9QGJ