### PR TITLE
Bump the crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xn"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "ash",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "xn-moshi"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["xn-flash-attn"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.16"
+version = "0.1.17"
 description = "Another minimalist deep-learning framework optimized for inference."
 repository = "https://github.com/LaurentMazare/xn"
 keywords = ["pytorch", "deep-learning", "machine-learning"]
@@ -15,7 +15,7 @@ categories = ["science"]
 license = "MIT/Apache-2.0"
 
 [workspace.dependencies]
-xn = { path = "xn-core", version = "0.1.16" }
+xn = { path = "xn-core", version = "0.1.17" }
 anyhow = "1"
 ash = "0.38"
 bindgen_cuda = "0.1.6"

--- a/xn-flash-attn/Cargo.toml
+++ b/xn-flash-attn/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["science"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-xn = { path = "../xn-core", features = ["cuda"], version = "0.1.16" }
+xn = { path = "../xn-core", features = ["cuda"], version = "0.1.17" }
 cudarc = { version = "0.19.4", features = ["driver"], default-features = false }
 half = { version = "2.7.1", features = ["num-traits"] }
 


### PR DESCRIPTION
Bumps `xn` from 0.1.16 to 0.1.17 (workspace version, the `xn` dependency version constraints, and `Cargo.lock`), following the same pattern as previous version-bump commits. Picks up the Vulkan GEMV vec4-load (#39) and conv1d/conv_transpose1d im2col/col2im (#40) changes merged since 0.1.16.

https://claude.ai/code/session_01QmiSVGYBiB9DaQ3r8p9QGJ