### PR TITLE
Fix clippy lints.

### DIFF
--- a/xn-core/src/shape.rs
+++ b/xn-core/src/shape.rs
@@ -8,7 +8,7 @@ pub const SCALAR: Shape = Shape(vec![]);
 
 impl std::fmt::Debug for Shape {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", &self.dims())
+        write!(f, "{:?}", self.dims())
     }
 }
 

--- a/xn-moshi/src/conditioners.rs
+++ b/xn-moshi/src/conditioners.rs
@@ -283,7 +283,7 @@ impl<T: xn::WithDTypeF, B: xn::Backend> Conditioners<T, B> {
                 None => emb,
             });
         }
-        for (_name, source_level) in self.source_level.iter() {
+        for source_level in self.source_level.values() {
             result = Some(match result {
                 Some(acc) => acc.add(&source_level.learnt_padding)?,
                 None => source_level.learnt_padding.clone(),

--- a/xn-moshi/src/s2s.rs
+++ b/xn-moshi/src/s2s.rs
@@ -481,10 +481,7 @@ impl<Q: BackendQ> State<Q> {
     }
 
     pub fn last_audio_tokens(&self) -> Option<Vec<Vec<i64>>> {
-        let max_delay = match self.model.audio_delays.iter().max() {
-            Some(d) => *d,
-            None => return None,
-        };
+        let max_delay = *self.model.audio_delays.iter().max()?;
         let mut last_tokens = Vec::with_capacity(self.batch_size());
         let n_slices = self.model.depformer.len();
         for per_batch in self.per_batch.iter() {


### PR DESCRIPTION
- shape.rs: drop a redundant borrow in a write! argument.
- conditioners.rs: iterate over map values instead of (key, value) pairs.
- s2s.rs: replace an Option match with ?.


Claude-Session: https://claude.ai/code/session_01F6TjSFkyRSjRHGtgvuA7RL