### PR TITLE
Ignore size-1 dims in the contiguity check.

### DIFF
--- a/xn-core/src/shape.rs
+++ b/xn-core/src/shape.rs
@@ -144,7 +144,10 @@ impl Shape {
         }
         let mut acc = 1;
         for (&stride, &dim) in stride.iter().zip(self.0.iter()).rev() {
-            if stride != acc {
+            // The stride of a size-1 dimension never affects addressing, so it does not
+            // matter for contiguity; this notably makes transposes that only move a size-1
+            // dimension (e.g. seq-len 1 in decode attention) zero-copy.
+            if dim != 1 && stride != acc {
                 return false;
             }
             acc *= dim;


### PR DESCRIPTION
The stride of a size-1 dimension never affects addressing, so it does not matter for contiguity. This makes transposes that only move a size-1 dimension zero-copy in TensorView::contiguous() instead of a full copy; the q/k/v and attention-output transposes in seq-len 1 decode attention are the main beneficiaries.

On the moshi asr example (cuda, bf16), this removes ~67k copy kernels per run and speeds it up by 5.8% at batch-size 1 (8.10s -> 7.63s) and 2.3% at batch-size 32 (13.70s -> 13.39s), with identical transcripts.


Claude-Session: https://claude.ai/code/session_01F6TjSFkyRSjRHGtgvuA7RL