### PR TITLE
Fix batched matmul with non-collapsible batch strides

### DIFF
--- a/xn-core/src/inplace_ops.rs
+++ b/xn-core/src/inplace_ops.rs
@@ -83,6 +83,43 @@ macro_rules! binary_op {
     };
 }
 
+/// Uniform stride covering a row-major flat iteration of the batch dims (all but the
+/// last two), when the layout admits one; size-1 dims never contribute to an offset
+/// and are ignored. Contiguous tensors always admit one; strided views may not, e.g.
+/// the (b, h) batch dims of a transpose(1, 2) view of a (b, t, h, d) tensor have
+/// strides (t*h*d, d) which cannot be walked with a single stride when b > 1.
+fn flat_batch_stride(dims: &[usize], strides: &[usize]) -> Option<usize> {
+    let nb = dims.len().saturating_sub(2);
+    let mut step = None;
+    let mut suffix = 1usize;
+    for j in (0..nb).rev() {
+        if dims[j] == 1 {
+            continue;
+        }
+        match step {
+            None => step = Some(strides[j]),
+            Some(s) => {
+                if strides[j] != s * suffix {
+                    return None;
+                }
+            }
+        }
+        suffix *= dims[j];
+    }
+    Some(step.unwrap_or(0))
+}
+
+/// Materialize a contiguous copy of an arbitrarily strided operand.
+fn contiguous_copy<T: WithDType, B: Backend>(src: &dyn TensorOrView<T, B>) -> Result<Tensor<T, B>> {
+    let dst: Tensor<T, B> = unsafe { Tensor::alloc_uninit(src.shape().clone(), src.device()) }?;
+    {
+        let (src_data, src_o) = src.storage_and_offset()?;
+        let mut dst_data = dst.storage_mut()?;
+        B::copy_strided(&mut dst_data, &*src_data, src_o, src.dims(), &src.strides())?;
+    }
+    Ok(dst)
+}
+
 impl<T: WithDType, B: Backend> Tensor<T, B> {
     fn check_not_same_storage(&self, other: &Self, op: &str) -> Result<()> {
         if Arc::ptr_eq(&self.data, &other.data) {
@@ -443,6 +480,28 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
             );
         }
 
+        // The backend gemm walks the flattened batch space with a single uniform stride
+        // per operand. When the batch dims of a strided view do not collapse to such a
+        // stride (e.g. a transpose(1, 2) view of a (b, t, h, d) tensor with b > 1),
+        // materialize a contiguous copy of the operand first — otherwise every batch
+        // entry past the first would read from wrong offsets.
+        let lhs_contiguous;
+        let lhs: &dyn TensorOrView<T, B> = if flat_batch_stride(lhs_dims, &lhs.strides()).is_some()
+        {
+            lhs
+        } else {
+            lhs_contiguous = contiguous_copy(lhs)?;
+            &lhs_contiguous
+        };
+        let rhs_contiguous;
+        let rhs: &dyn TensorOrView<T, B> =
+            if rhs_batch == 1 || flat_batch_stride(rhs_dims, &rhs.strides()).is_some() {
+                rhs
+            } else {
+                rhs_contiguous = contiguous_copy(rhs)?;
+                &rhs_contiguous
+            };
+
         // Use actual strides from the TensorOrView to support non-contiguous inputs
         // (e.g. transposed views passed directly to matmul).
         let lhs_s = lhs.strides();
@@ -459,13 +518,17 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
             (rhs_s[rhs_s.len() - 1], rhs_s[rhs_s.len() - 2])
         };
 
-        let lhs_b_stride = if lhs_s.len() >= 3 { lhs_s[lhs_s.len() - 3] } else { m * k };
+        let lhs_b_stride = match flat_batch_stride(lhs_dims, &lhs_s) {
+            Some(s) if lhs_s.len() >= 3 => s,
+            _ => m * k,
+        };
         let rhs_b_stride = if rhs_batch == 1 {
             0
-        } else if rhs_s.len() >= 3 {
-            rhs_s[rhs_s.len() - 3]
         } else {
-            rhs_dims[rhs_dims.len() - 2] * rhs_dims[rhs_dims.len() - 1]
+            match flat_batch_stride(rhs_dims, &rhs_s) {
+                Some(s) if rhs_s.len() >= 3 => s,
+                _ => rhs_dims[rhs_dims.len() - 2] * rhs_dims[rhs_dims.len() - 1],
+            }
         };
 
         let mut dst = self.storage_mut()?;

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1752,3 +1752,38 @@ fn test_narrow_prefix_contiguous_impl<B: Backend>(dev: &B) -> Result<()> {
     Ok(())
 }
 test_all_backends!(test_narrow_prefix_contiguous, test_narrow_prefix_contiguous_impl);
+
+fn test_matmul_batched_strided_impl<B: Backend>(dev: &B) -> Result<()> {
+    // Batched matmuls where an operand is a transpose(1, 2) view of a (b, t, h, d)
+    // tensor: the batch dims (b, h) of the view have strides (t*h*d, d), which do not
+    // collapse to a single uniform batch stride when b > 1. Regression test: batch
+    // entries past the first used to read from wrong offsets (the attention pattern of
+    // a batched transformer, where only batch row 0 came out right).
+    let (b, t, h, d) = (3, 5, 2, 4);
+    let q_data: Vec<f32> = (0..b * t * h * d).map(|i| ((i * 7 % 23) as f32) - 11.0).collect();
+    let k_data: Vec<f32> = (0..b * t * h * d).map(|i| ((i * 5 % 19) as f32) - 9.0).collect();
+    let q: Tensor<f32, B> = Tensor::from_vec(q_data, (b, t, h, d), dev)?;
+    let k: Tensor<f32, B> = Tensor::from_vec(k_data, (b, t, h, d), dev)?;
+
+    // (b, t, h, d) -> (b, h, t, d) views with non-collapsible batch strides.
+    let q_view = q.transpose(1, 2)?;
+    let k_view = k.transpose(1, 2)?;
+    let q_c = q.transpose(1, 2)?.contiguous()?;
+    let k_c = k.transpose(1, 2)?.contiguous()?;
+
+    // matmul_t: (b, h, t, d) x (b, h, t, d)^T -> (b, h, t, t)
+    let expected = q_c.matmul_t(&k_c)?.to_vec()?;
+    assert_approx_eq(&q_view.matmul_t(&k_c)?.to_vec()?, &expected, 1e-5);
+    assert_approx_eq(&q_c.matmul_t(&k_view)?.to_vec()?, &expected, 1e-5);
+    assert_approx_eq(&q_view.matmul_t(&k_view)?.to_vec()?, &expected, 1e-5);
+
+    // matmul: (b, h, t, d) x (b, h, d, t) -> (b, h, t, t)
+    let k_tt_view = k.transpose(1, 2)?.transpose(2, 3)?;
+    let k_tt_c = k.transpose(1, 2)?.transpose(2, 3)?.contiguous()?;
+    let expected = q_c.matmul(&k_tt_c)?.to_vec()?;
+    assert_approx_eq(&q_view.matmul(&k_tt_c)?.to_vec()?, &expected, 1e-5);
+    assert_approx_eq(&q_c.matmul(&k_tt_view)?.to_vec()?, &expected, 1e-5);
+    assert_approx_eq(&q_view.matmul(&k_tt_view)?.to_vec()?, &expected, 1e-5);
+    Ok(())
+}
+test_all_backends!(test_matmul_batched_strided, test_matmul_batched_strided_impl);


### PR DESCRIPTION
## Problem

`Tensor::matmul_` flattens all leading batch dims into a single count but takes the batch stride from the innermost batch dim alone (`strides[len - 3]`). The backend `gemm` then walks matrix `i` at `base + i * stride`. That is only valid when the batch dims collapse to one uniform stride — always true for contiguous tensors, not for strided views.

For a `transpose(1, 2)` view of a `(b, t, h, d)` tensor (the attention pattern of a batched transformer), matrix `(b, h)` lives at `b·(t·h·d) + h·d`, which needs two strides. With `b > 1` every batch entry past the first was read from a wrong offset: batch row 0 came out correct and all other rows were silently corrupted. This surfaced in xn-ptts as garbled audio for every batched TTS item except the first.

## Fix

- `flat_batch_stride(dims, strides)` checks whether the batch dims admit a single flat-iteration stride (size-1 dims are position-free and ignored) and returns it.
- When an operand does not admit one, `matmul_` materializes a contiguous copy of it first (`contiguous_copy`, generic over `TensorOrView`). Since this happens before dispatch, all backends are covered.
- Collapsible layouts — including all contiguous tensors and last-two-dim transposes — keep the previous zero-copy path byte-for-byte. The batch stride passed to `B::gemm` is now derived from the same check, which also covers layouts whose innermost batch dim has size 1 with a meaningless stride.

## Test

`test_matmul_batched_strided` (runs on every enabled backend) builds `(b=3, t=5, h=2, d=4)` tensors, takes `transpose(1, 2)` views, and checks `matmul` / `matmul_t` against the contiguous reference for every strided/contiguous operand combination. It fails on `main` with `mismatch at index 50: 124 vs -36` and passes with this change, on both CPU and CUDA.

`cargo test`, `cargo test --features cuda` (tensor + cuda suites), `cargo fmt --check` and `cargo clippy` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9wS7BeyvE4mfMPRqgEeqK