### PR TITLE
Add an explicit output type to the WithQ trait.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,7 +3605,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xn"
-version = "0.1.21"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ash",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "xn-moshi"
-version = "0.1.21"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["xn-flash-attn"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.21"
+version = "0.2.0"
 description = "Another minimalist deep-learning framework optimized for inference."
 repository = "https://github.com/LaurentMazare/xn"
 keywords = ["pytorch", "deep-learning", "machine-learning"]
@@ -15,7 +15,7 @@ categories = ["science"]
 license = "MIT/Apache-2.0"
 
 [workspace.dependencies]
-xn = { path = "xn-core", version = "0.1.21" }
+xn = { path = "xn-core", version = "0.2.0" }
 anyhow = "1"
 ash = "0.38"
 bindgen_cuda = "0.1.6"

--- a/xn-core/src/lib.rs
+++ b/xn-core/src/lib.rs
@@ -138,54 +138,45 @@ impl<T: WithDTypeF, B: Backend> BackendQ for Unquantized<T, B> {
 }
 
 pub trait WithQ {
-    fn run<Q: BackendQ>(self, dev: Q::B) -> Result<()>;
+    type Output;
+    fn run<Q: BackendQ>(self, dev: Q::B) -> Result<Self::Output>;
 }
 
-pub fn run_with_device<W: WithQ>(w: W, _cpu_only: bool, _device_id: usize) -> Result<()> {
+pub fn run_with_device<W: WithQ>(w: W, _cpu_only: bool, _device_id: usize) -> Result<W::Output> {
     #[cfg(feature = "cuda")]
-    {
-        if _cpu_only {
-            w.run::<Unquantized<f32, _>>(CpuDevice)?;
-        } else {
-            let dev = cuda_backend::Device::new(_device_id)?;
-            w.run::<Unquantized<half::bf16, _>>(dev)?;
-        }
-    }
+    let res = if _cpu_only {
+        w.run::<Unquantized<f32, _>>(CpuDevice)
+    } else {
+        let dev = cuda_backend::Device::new(_device_id)?;
+        w.run::<Unquantized<half::bf16, _>>(dev)
+    };
     #[cfg(all(feature = "vulkan", not(feature = "cuda")))]
-    {
-        if _cpu_only {
-            w.run::<Unquantized<f32, _>>(CpuDevice)?;
-        } else {
-            let dev = vulkan_backend::Device::new(_device_id)?;
-            w.run::<Unquantized<f32, _>>(dev)?;
-        }
-    }
+    let res = if _cpu_only {
+        w.run::<Unquantized<f32, _>>(CpuDevice)
+    } else {
+        let dev = vulkan_backend::Device::new(_device_id)?;
+        w.run::<Unquantized<f32, _>>(dev)
+    };
     #[cfg(all(feature = "metal", not(any(feature = "cuda", feature = "vulkan"))))]
-    {
-        if _cpu_only {
-            w.run::<Unquantized<f32, _>>(CpuDevice)?;
-        } else {
-            let dev = metal_backend::Device::new(_device_id)?;
-            w.run::<Unquantized<f32, _>>(dev)?;
-        }
-    }
+    let res = if _cpu_only {
+        w.run::<Unquantized<f32, _>>(CpuDevice)
+    } else {
+        let dev = metal_backend::Device::new(_device_id)?;
+        w.run::<Unquantized<f32, _>>(dev)
+    };
     #[cfg(all(
         feature = "webgpu",
         not(any(feature = "cuda", feature = "vulkan", feature = "metal"))
     ))]
-    {
-        if _cpu_only {
-            w.run::<Unquantized<f32, _>>(CpuDevice)?;
-        } else {
-            let dev = webgpu_backend::Device::new(_device_id)?;
-            w.run::<Unquantized<f32, _>>(dev)?;
-        }
-    }
+    let res = if _cpu_only {
+        w.run::<Unquantized<f32, _>>(CpuDevice)
+    } else {
+        let dev = webgpu_backend::Device::new(_device_id)?;
+        w.run::<Unquantized<f32, _>>(dev)
+    };
     #[cfg(not(any(feature = "cuda", feature = "vulkan", feature = "metal", feature = "webgpu")))]
-    {
-        w.run::<Unquantized<f32, _>>(CpuDevice)?;
-    }
-    Ok(())
+    let res = w.run::<Unquantized<f32, _>>(CpuDevice);
+    res
 }
 
 pub struct Runner {
@@ -208,137 +199,133 @@ impl Runner {
         self
     }
 
-    pub fn run<W: WithQ>(self, w: W, _device_id: usize) -> Result<()> {
-        #[cfg(feature = "cuda")]
-        {
-            if self.cpu_only {
-                w.run::<Unquantized<f32, _>>(CpuDevice)?;
-            } else {
-                let dev = cuda_backend::Device::new(_device_id)?;
-                match self.dtype {
-                    DTypeQ::Fp8 => w.run::<cuda_backend::quantization::Fp8ScalePerTensor>(dev)?,
-                    DTypeQ::Fp8PerToken => {
-                        w.run::<cuda_backend::quantization::Fp8ScalePerToken>(dev)?
-                    }
-                    DTypeQ::F16 => w.run::<Unquantized<half::f16, _>>(dev)?,
-                    DTypeQ::BF16 => w.run::<Unquantized<half::bf16, _>>(dev)?,
-                    DTypeQ::F32 => w.run::<Unquantized<f32, _>>(dev)?,
-                    DTypeQ::Q4_0
-                    | DTypeQ::Q4_1
-                    | DTypeQ::Q5_0
-                    | DTypeQ::Q5_1
-                    | DTypeQ::Q8_0
-                    | DTypeQ::Q8_1
-                    | DTypeQ::Q2K
-                    | DTypeQ::Q3K
-                    | DTypeQ::Q4K
-                    | DTypeQ::Q5K
-                    | DTypeQ::Q6K
-                    | DTypeQ::Q8K => {
-                        return Err(Error::msg(format!(
-                            "{:?} quantization is only supported on CPU",
-                            self.dtype
-                        )));
-                    }
-                }
+    /// Run on the CPU backend, using the quantized kernels when the dtype
+    /// calls for them.
+    #[cfg(not(feature = "cuda"))]
+    fn run_cpu<W: WithQ>(&self, w: W) -> Result<W::Output> {
+        match self.dtype {
+            DTypeQ::Fp8 | DTypeQ::Fp8PerToken => {
+                Err(Error::msg("FP8 quantization is not supported on CPU"))
+            }
+            DTypeQ::F32 => w.run::<Unquantized<f32, _>>(CpuDevice),
+            DTypeQ::Q4_0 => w.run::<crate::quantized::Q40F32>(CpuDevice),
+            DTypeQ::Q4_1 => w.run::<crate::quantized::Q41F32>(CpuDevice),
+            DTypeQ::Q5_0 => w.run::<crate::quantized::Q50F32>(CpuDevice),
+            DTypeQ::Q5_1 => w.run::<crate::quantized::Q51F32>(CpuDevice),
+            DTypeQ::Q8_0 => w.run::<crate::quantized::Q80F32>(CpuDevice),
+            DTypeQ::Q8_1 => w.run::<crate::quantized::Q81F32>(CpuDevice),
+            DTypeQ::Q2K => w.run::<crate::quantized::Q2kF32>(CpuDevice),
+            DTypeQ::Q3K => w.run::<crate::quantized::Q3kF32>(CpuDevice),
+            DTypeQ::Q4K => w.run::<crate::quantized::Q4kF32>(CpuDevice),
+            DTypeQ::Q5K => w.run::<crate::quantized::Q5kF32>(CpuDevice),
+            DTypeQ::Q6K => w.run::<crate::quantized::Q6kF32>(CpuDevice),
+            DTypeQ::Q8K => w.run::<crate::quantized::Q8kF32>(CpuDevice),
+            DTypeQ::F16 | DTypeQ::BF16 => {
+                Err(Error::msg(format!("{:?} is not yet supported on CPU", self.dtype)))
             }
         }
+    }
+
+    pub fn run<W: WithQ>(self, w: W, _device_id: usize) -> Result<W::Output> {
+        #[cfg(feature = "cuda")]
+        let res = if self.cpu_only {
+            w.run::<Unquantized<f32, _>>(CpuDevice)
+        } else {
+            let dev = cuda_backend::Device::new(_device_id)?;
+            match self.dtype {
+                DTypeQ::Fp8 => w.run::<cuda_backend::quantization::Fp8ScalePerTensor>(dev),
+                DTypeQ::Fp8PerToken => w.run::<cuda_backend::quantization::Fp8ScalePerToken>(dev),
+                DTypeQ::F16 => w.run::<Unquantized<half::f16, _>>(dev),
+                DTypeQ::BF16 => w.run::<Unquantized<half::bf16, _>>(dev),
+                DTypeQ::F32 => w.run::<Unquantized<f32, _>>(dev),
+                DTypeQ::Q4_0
+                | DTypeQ::Q4_1
+                | DTypeQ::Q5_0
+                | DTypeQ::Q5_1
+                | DTypeQ::Q8_0
+                | DTypeQ::Q8_1
+                | DTypeQ::Q2K
+                | DTypeQ::Q3K
+                | DTypeQ::Q4K
+                | DTypeQ::Q5K
+                | DTypeQ::Q6K
+                | DTypeQ::Q8K => Err(Error::msg(format!(
+                    "{:?} quantization is only supported on CPU",
+                    self.dtype
+                ))),
+            }
+        };
         #[cfg(all(feature = "vulkan", not(feature = "cuda")))]
-        {
+        let res = if self.cpu_only {
+            self.run_cpu(w)
+        } else {
             // The Vulkan backend computes in f32, f16 or bf16 (device
             // permitting). Quantized formats stay on CPU.
-            if !self.cpu_only {
-                match self.dtype {
-                    DTypeQ::F32 => {
-                        let dev = vulkan_backend::Device::new(_device_id)?;
-                        w.run::<Unquantized<f32, _>>(dev)?;
-                        return Ok(());
-                    }
-                    DTypeQ::F16 => {
-                        let dev = vulkan_backend::Device::new(_device_id)?;
-                        if !dev.supports_f16() {
-                            return Err(Error::msg("vulkan device does not support f16"));
-                        }
-                        w.run::<Unquantized<half::f16, _>>(dev)?;
-                        return Ok(());
-                    }
-                    DTypeQ::BF16 => {
-                        let dev = vulkan_backend::Device::new(_device_id)?;
-                        if !dev.supports_bf16() {
-                            return Err(Error::msg("vulkan device does not support bf16"));
-                        }
-                        w.run::<Unquantized<half::bf16, _>>(dev)?;
-                        return Ok(());
-                    }
-                    _ => {}
+            match self.dtype {
+                DTypeQ::F32 => {
+                    let dev = vulkan_backend::Device::new(_device_id)?;
+                    w.run::<Unquantized<f32, _>>(dev)
                 }
+                DTypeQ::F16 => {
+                    let dev = vulkan_backend::Device::new(_device_id)?;
+                    if !dev.supports_f16() {
+                        Err(Error::msg("vulkan device does not support f16"))
+                    } else {
+                        w.run::<Unquantized<half::f16, _>>(dev)
+                    }
+                }
+                DTypeQ::BF16 => {
+                    let dev = vulkan_backend::Device::new(_device_id)?;
+                    if !dev.supports_bf16() {
+                        Err(Error::msg("vulkan device does not support bf16"))
+                    } else {
+                        w.run::<Unquantized<half::bf16, _>>(dev)
+                    }
+                }
+                _ => self.run_cpu(w),
             }
-        }
+        };
         #[cfg(all(feature = "metal", not(any(feature = "cuda", feature = "vulkan"))))]
-        {
+        let res = if self.cpu_only {
+            self.run_cpu(w)
+        } else {
             // The Metal backend computes in f32 with f16 or bf16 storage also
             // supported. Quantized formats stay on CPU.
-            if !self.cpu_only {
-                match self.dtype {
-                    DTypeQ::F32 => {
-                        let dev = metal_backend::Device::new(_device_id)?;
-                        w.run::<Unquantized<f32, _>>(dev)?;
-                        return Ok(());
-                    }
-                    DTypeQ::F16 => {
-                        let dev = metal_backend::Device::new(_device_id)?;
-                        w.run::<Unquantized<half::f16, _>>(dev)?;
-                        return Ok(());
-                    }
-                    DTypeQ::BF16 => {
-                        let dev = metal_backend::Device::new(_device_id)?;
-                        w.run::<Unquantized<half::bf16, _>>(dev)?;
-                        return Ok(());
-                    }
-                    _ => {}
+            match self.dtype {
+                DTypeQ::F32 => {
+                    let dev = metal_backend::Device::new(_device_id)?;
+                    w.run::<Unquantized<f32, _>>(dev)
                 }
+                DTypeQ::F16 => {
+                    let dev = metal_backend::Device::new(_device_id)?;
+                    w.run::<Unquantized<half::f16, _>>(dev)
+                }
+                DTypeQ::BF16 => {
+                    let dev = metal_backend::Device::new(_device_id)?;
+                    w.run::<Unquantized<half::bf16, _>>(dev)
+                }
+                _ => self.run_cpu(w),
             }
-        }
+        };
         #[cfg(all(
             feature = "webgpu",
             not(any(feature = "cuda", feature = "vulkan", feature = "metal"))
         ))]
-        {
+        let res = if !self.cpu_only && self.dtype == DTypeQ::F32 {
             // The WebGPU backend computes in f32; other formats stay on CPU.
-            if !self.cpu_only && self.dtype == DTypeQ::F32 {
-                let dev = webgpu_backend::Device::new(_device_id)?;
-                w.run::<Unquantized<f32, _>>(dev)?;
-                return Ok(());
-            }
-        }
-        #[cfg(not(feature = "cuda"))]
-        {
-            match self.dtype {
-                DTypeQ::Fp8 | DTypeQ::Fp8PerToken => {
-                    return Err(Error::msg("FP8 quantization is not supported on CPU"));
-                }
-                DTypeQ::F32 => w.run::<Unquantized<f32, _>>(CpuDevice)?,
-                DTypeQ::Q4_0 => w.run::<crate::quantized::Q40F32>(CpuDevice)?,
-                DTypeQ::Q4_1 => w.run::<crate::quantized::Q41F32>(CpuDevice)?,
-                DTypeQ::Q5_0 => w.run::<crate::quantized::Q50F32>(CpuDevice)?,
-                DTypeQ::Q5_1 => w.run::<crate::quantized::Q51F32>(CpuDevice)?,
-                DTypeQ::Q8_0 => w.run::<crate::quantized::Q80F32>(CpuDevice)?,
-                DTypeQ::Q8_1 => w.run::<crate::quantized::Q81F32>(CpuDevice)?,
-                DTypeQ::Q2K => w.run::<crate::quantized::Q2kF32>(CpuDevice)?,
-                DTypeQ::Q3K => w.run::<crate::quantized::Q3kF32>(CpuDevice)?,
-                DTypeQ::Q4K => w.run::<crate::quantized::Q4kF32>(CpuDevice)?,
-                DTypeQ::Q5K => w.run::<crate::quantized::Q5kF32>(CpuDevice)?,
-                DTypeQ::Q6K => w.run::<crate::quantized::Q6kF32>(CpuDevice)?,
-                DTypeQ::Q8K => w.run::<crate::quantized::Q8kF32>(CpuDevice)?,
-                DTypeQ::F16 | DTypeQ::BF16 => {
-                    return Err(Error::msg(format!(
-                        "{:?} is not yet supported on CPU",
-                        self.dtype
-                    )));
-                }
-            };
-        }
-        Ok(())
+            let dev = webgpu_backend::Device::new(_device_id)?;
+            w.run::<Unquantized<f32, _>>(dev)
+        } else {
+            self.run_cpu(w)
+        };
+        #[cfg(not(any(
+            feature = "cuda",
+            feature = "vulkan",
+            feature = "metal",
+            feature = "webgpu"
+        )))]
+        let res = self.run_cpu(w);
+        res
     }
 }
 

--- a/xn-flash-attn/Cargo.toml
+++ b/xn-flash-attn/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["science"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-xn = { path = "../xn-core", features = ["cuda"], version = "0.1.21" }
+xn = { path = "../xn-core", features = ["cuda"], version = "0.2.0" }
 cudarc = { version = "0.19.4", features = ["driver"], default-features = false }
 half = { version = "2.7.1", features = ["num-traits"] }
 

--- a/xn-moshi/examples/moshi.rs
+++ b/xn-moshi/examples/moshi.rs
@@ -213,6 +213,7 @@ struct AsrQ {
 }
 
 impl xn::WithQ for AsrQ {
+    type Output = ();
     fn run<Q: xn::BackendQ>(self, dev: Q::B) -> xn::Result<()> {
         match run_asr::<Q>(
             self.input,
@@ -239,6 +240,7 @@ struct S2s {
 }
 
 impl xn::WithQ for S2s {
+    type Output = ();
     fn run<Q: xn::BackendQ>(self, dev: Q::B) -> xn::Result<()> {
         match run_s2s::<Q>(
             self.input,


### PR DESCRIPTION
Adds an associated `type Output` to the `WithQ` trait so that `run` implementations can return a value. `run_with_device` and `Runner::run` now return `Result<W::Output>` instead of discarding the result behind `Result<()>`.

To keep `Runner::run` free of early returns, the CPU dispatch (quantized kernels + f32) is factored into a `run_cpu` helper that the Vulkan/Metal/WebGPU branches fall back to for `cpu_only` and quantized dtypes; each `#[cfg]` backend branch binds its result and the function yields it as the tail expression. Existing behavior is unchanged, and the `WithQ` impls in the moshi example set `type Output = ()`.

Tested on default (CPU), `cuda`, `vulkan`, and `webgpu` feature sets: `cargo test` and `cargo clippy` all pass (metal not runnable on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jfab9rkKiFDZdZTZK2SPwd