### PR TITLE
Add CUDA graph capture support to the cuda backend.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,7 +3605,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xn"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "ash",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "xn-moshi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["xn-flash-attn"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 description = "Another minimalist deep-learning framework optimized for inference."
 repository = "https://github.com/LaurentMazare/xn"
 keywords = ["pytorch", "deep-learning", "machine-learning"]
@@ -15,7 +15,7 @@ categories = ["science"]
 license = "MIT/Apache-2.0"
 
 [workspace.dependencies]
-xn = { path = "xn-core", version = "0.2.0" }
+xn = { path = "xn-core", version = "0.2.1" }
 anyhow = "1"
 ash = "0.38"
 bindgen_cuda = "0.1.6"

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -42,6 +42,18 @@ struct ModuleCache {
     rope: Option<Arc<cudarc::driver::CudaModule>>,
 }
 
+/// Host-to-device upload mode, see [`Device::capture_record_begin`].
+mod htod_mode {
+    pub const PASSTHROUGH: u8 = 0;
+    pub const RECORD: u8 = 1;
+    pub const REPLAY: u8 = 2;
+}
+
+/// Device buffers holding recorded host uploads, keyed by element type name
+/// and content bytes. Values are `CudaSlice<T>` boxed as `Any`.
+type HtodCache =
+    Mutex<std::collections::HashMap<(&'static str, Vec<u8>), Box<dyn std::any::Any + Send>>>;
+
 pub struct DeviceInner {
     cuda: Arc<CudaContext>,
     stream: Arc<CudaStream>,
@@ -50,6 +62,14 @@ pub struct DeviceInner {
     curand: Mutex<CudaRng>,
     /// Cache for loaded PTX modules
     modules: Mutex<ModuleCache>,
+    /// Host-to-device upload mode used by CUDA-graph capture, one of the
+    /// [`htod_mode`] constants.
+    htod_mode: std::sync::atomic::AtomicU8,
+    /// Device-side copies of host uploads recorded in [`htod_mode::RECORD`].
+    /// In [`htod_mode::REPLAY`] (i.e. while capturing) uploads are served
+    /// from these buffers through device-to-device copies, which are legal
+    /// inside a capture while a pageable host copy is not.
+    htod_cache: HtodCache,
 }
 
 pub struct CudaEvent {
@@ -78,6 +98,28 @@ impl CudaEvent {
     }
 }
 
+/// An instantiated CUDA graph, see [`Device::capture_begin`]. Replaying it
+/// re-runs the captured kernels against the buffer addresses they were
+/// captured with: refresh the input buffers in place, [`CaptureGraph::launch`],
+/// then read the output buffers.
+pub struct CaptureGraph(cudarc::driver::CudaGraph);
+
+// SAFETY: `CudaGraph` is not auto-Send because it holds raw
+// `CUgraph`/`CUgraphExec` handles, but those are plain context-scoped driver
+// handles with no thread affinity; cudarc re-binds the CUDA context on every
+// call. `CaptureGraph` is deliberately not `Sync`: `launch` must not be
+// called concurrently from two threads.
+unsafe impl Send for CaptureGraph {}
+
+impl CaptureGraph {
+    /// Enqueue a replay of the captured work on the stream it was captured
+    /// from. Like any kernel launch this is asynchronous.
+    pub fn launch(&self) -> Result<()> {
+        self.0.launch()?;
+        Ok(())
+    }
+}
+
 #[derive(Clone)]
 pub struct Device(Arc<DeviceInner>);
 
@@ -97,7 +139,17 @@ impl std::fmt::Debug for Device {
 impl Device {
     pub fn new(ordinal: usize) -> Result<Self> {
         let cuda = cudarc::driver::CudaContext::new(ordinal)?;
-        let stream = cuda.default_stream();
+        // A proper (non-legacy) stream: the NULL default stream cannot be
+        // captured into a CUDA graph. All work goes through this one stream,
+        // so the synchronization semantics are unchanged.
+        let stream = cuda.new_stream()?;
+        // Creating a stream flips cudarc into multi-stream mode, which turns
+        // on per-slice event waits; on our single stream they are pure
+        // overhead, and events recorded before a CUDA-graph capture would
+        // make the capture fail with CUDA_ERROR_STREAM_CAPTURE_ISOLATION.
+        // SAFETY: all work runs on the single stream created above, so
+        // stream-order already synchronizes every use.
+        unsafe { cuda.disable_event_tracking() };
         let blas = cudarc::cublas::CudaBlas::new(stream.clone())?;
         let blas_lt = cublaslt::CudaBlasLT::new(stream.clone())?;
         let curand = cudarc::curand::CudaRng::new(299792458, stream.clone())?;
@@ -108,11 +160,144 @@ impl Device {
             blas_lt,
             modules: Mutex::new(Default::default()),
             curand: Mutex::new(CudaRng(curand)),
+            htod_mode: std::sync::atomic::AtomicU8::new(0),
+            htod_cache: Mutex::new(std::collections::HashMap::new()),
         })))
     }
 
     pub fn stream(&self) -> &Arc<CudaStream> {
         &self.stream
+    }
+
+    /// Host-to-device upload that stays legal inside a CUDA-graph capture.
+    ///
+    /// In passthrough mode this is a plain [`CudaStream::clone_htod`]. In
+    /// record mode (between [`Device::capture_record_begin`] and
+    /// [`Device::capture_record_end`]) every upload also stores a persistent
+    /// device-side copy keyed by its content. In replay mode (between
+    /// [`Device::capture_begin`] and [`Device::capture_end`], i.e. while the
+    /// stream is capturing) the upload is served without touching host
+    /// memory: an in-capture allocation filled by a device-to-device copy
+    /// from the recorded buffer; content that was not recorded beforehand is
+    /// an error. This is only correct for uploads whose content is identical
+    /// between the record pass and every replay of the captured graph
+    /// (kernel shape/stride descriptors, position tables, masks, ...).
+    pub(crate) fn cached_htod<T: cudarc::driver::DeviceRepr + Copy + Send + 'static>(
+        &self,
+        v: &[T],
+    ) -> Result<CudaSlice<T>> {
+        use std::sync::atomic::Ordering;
+        let mode = self.htod_mode.load(Ordering::Relaxed);
+        if mode == htod_mode::PASSTHROUGH {
+            return Ok(self.stream.clone_htod(v)?);
+        }
+        let bytes = unsafe {
+            std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v))
+        };
+        let key = (std::any::type_name::<T>(), bytes.to_vec());
+        let mut cache = self.htod_cache.lock().unwrap();
+        if mode == htod_mode::RECORD && !cache.contains_key(&key) {
+            let staged = self.stream.clone_htod(v)?;
+            cache.insert(key.clone(), Box::new(staged));
+        }
+        let staged = match cache.get(&key) {
+            None => crate::bail!(
+                "htod upload of unrecorded content during CUDA graph capture ({} x{})",
+                std::any::type_name::<T>(),
+                v.len()
+            ),
+            Some(staged) => match staged.downcast_ref::<CudaSlice<T>>() {
+                None => crate::bail!("htod cache type confusion"),
+                Some(staged) => staged,
+            },
+        };
+        // Both record and replay take this path so that the record pass
+        // exercises exactly what the graph will capture.
+        let mut out = unsafe { self.stream.alloc::<T>(v.len()) }?;
+        self.stream.memcpy_dtod(staged, &mut out)?;
+        Ok(out)
+    }
+
+    fn set_htod_mode(&self, from: u8, to: u8, op: &str) -> Result<()> {
+        use std::sync::atomic::Ordering;
+        match self.htod_mode.compare_exchange(from, to, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => Ok(()),
+            Err(cur) => {
+                crate::bail!("{op}: unexpected htod mode {cur} (record/capture calls unbalanced?)")
+            }
+        }
+    }
+
+    /// Start recording host uploads in the device-side cache, see
+    /// [`Device::cached_htod`]. Run the exact workload to be captured once
+    /// under record mode before capturing it with [`Device::capture_begin`];
+    /// the recorded work executes normally.
+    pub fn capture_record_begin(&self) -> Result<()> {
+        self.set_htod_mode(htod_mode::PASSTHROUGH, htod_mode::RECORD, "capture_record_begin")
+    }
+
+    /// Stop recording host uploads.
+    pub fn capture_record_end(&self) -> Result<()> {
+        self.set_htod_mode(htod_mode::RECORD, htod_mode::PASSTHROUGH, "capture_record_end")
+    }
+
+    /// Begin capturing the device stream into a CUDA graph. The captured work
+    /// is recorded, not executed. Requires a prior record pass over the same
+    /// workload so that host uploads can be served from device buffers (see
+    /// [`Device::cached_htod`]); an upload of unrecorded content fails, in
+    /// which case the capture should be discarded with
+    /// [`Device::capture_abort`].
+    ///
+    /// The usual pattern, with all graph inputs and outputs living in
+    /// long-lived tensors that are refreshed in place:
+    /// 1. `capture_record_begin()`; run the workload; `capture_record_end()`.
+    /// 2. `capture_begin()`; run the workload again; `graph = capture_end()`.
+    /// 3. Per step: refresh the inputs, `graph.launch()`, read the outputs.
+    ///
+    /// Tensors created before the capture must not be dropped inside it (a
+    /// free of non-captured memory is invalid during capture), and tensors
+    /// created inside must not escape it.
+    pub fn capture_begin(&self) -> Result<()> {
+        self.set_htod_mode(htod_mode::PASSTHROUGH, htod_mode::REPLAY, "capture_begin")?;
+        let mode = cudarc::driver::sys::CUstreamCaptureMode::CU_STREAM_CAPTURE_MODE_RELAXED;
+        if let Err(err) = self.stream.begin_capture(mode) {
+            self.htod_mode.store(htod_mode::PASSTHROUGH, std::sync::atomic::Ordering::Relaxed);
+            Err(err)?
+        }
+        Ok(())
+    }
+
+    /// End the capture and instantiate the graph.
+    pub fn capture_end(&self) -> Result<CaptureGraph> {
+        self.htod_mode.store(htod_mode::PASSTHROUGH, std::sync::atomic::Ordering::Relaxed);
+        let flags =
+            cudarc::driver::sys::CUgraphInstantiate_flags::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH;
+        match self.stream.end_capture(flags)? {
+            None => crate::bail!("CUDA graph capture ended without a graph"),
+            Some(graph) => Ok(CaptureGraph(graph)),
+        }
+    }
+
+    /// Abort an in-progress capture, discarding the partially captured graph.
+    /// Errors from the discarded capture are ignored.
+    pub fn capture_abort(&self) {
+        self.htod_mode.store(htod_mode::PASSTHROUGH, std::sync::atomic::Ordering::Relaxed);
+        let flags =
+            cudarc::driver::sys::CUgraphInstantiate_flags::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH;
+        let _ = self.stream.end_capture(flags);
+    }
+
+    /// Number of distinct host uploads recorded for capture replay.
+    pub fn capture_cache_len(&self) -> usize {
+        self.htod_cache.lock().unwrap().len()
+    }
+
+    /// Drop every recorded host upload. The device-to-device copies baked
+    /// into a captured graph read from these buffers on every replay, so this
+    /// must only be called once no [`CaptureGraph`] captured from this cache
+    /// will be launched again.
+    pub fn capture_cache_clear(&self) {
+        self.htod_cache.lock().unwrap().clear();
     }
 
     pub fn event(&self) -> Result<CudaEvent> {
@@ -577,7 +762,7 @@ impl crate::Backend for Device {
     }
 
     fn from_vec<T: WithDType>(v: Vec<T>, dev: &Self) -> Result<Self::Storage<T>> {
-        let data = dev.stream.clone_htod(&v)?;
+        let data = dev.cached_htod(&v)?;
         Ok(Storage { data, device: dev.clone() })
     }
 
@@ -1096,7 +1281,7 @@ impl crate::Backend for Device {
 
         let num_dims = n;
         let info: Vec<usize> = dims.iter().chain(src_strides.iter()).copied().collect();
-        let info_dev = dst.device.stream.clone_htod(&info)?;
+        let info_dev = dst.device.cached_htod(&info)?;
 
         let kname = kernel_name::<T>("copy_strided");
         let func = dst.device.get_func(&kname, PTXModule::Layout)?;
@@ -1340,7 +1525,7 @@ impl crate::Backend for Device {
         let dims: [usize; 3] = [outer_size, inner_size, dim_size];
         let strides: [usize; 3] = [dim_size * inner_size, 1, inner_size];
         let info: Vec<usize> = dims.iter().chain(strides.iter()).copied().collect();
-        let info_dev = dst.device.stream.clone_htod(&info)?;
+        let info_dev = dst.device.cached_htod(&info)?;
 
         let kname = kernel_name::<T>("fast_max");
         let func = dst.device.get_func(&kname, PTXModule::Reduce)?;
@@ -1379,7 +1564,7 @@ impl crate::Backend for Device {
         let dims: [usize; 3] = [outer_size, inner_size, dim_size];
         let strides: [usize; 3] = [dim_size * inner_size, 1, inner_size];
         let info: Vec<usize> = dims.iter().chain(strides.iter()).copied().collect();
-        let info_dev = dst.device.stream.clone_htod(&info)?;
+        let info_dev = dst.device.cached_htod(&info)?;
 
         let kname = kernel_name::<T>("fast_min");
         let func = dst.device.get_func(&kname, PTXModule::Reduce)?;
@@ -1418,7 +1603,7 @@ impl crate::Backend for Device {
         let dims: [usize; 3] = [outer_size, inner_size, dim_size];
         let strides: [usize; 3] = [dim_size * inner_size, 1, inner_size];
         let info: Vec<usize> = dims.iter().chain(strides.iter()).copied().collect();
-        let info_dev = dst.device.stream.clone_htod(&info)?;
+        let info_dev = dst.device.cached_htod(&info)?;
 
         let kname = kernel_name::<T>("fast_argmin");
         let func = dst.device.get_func(&kname, PTXModule::Reduce)?;
@@ -1454,7 +1639,7 @@ impl crate::Backend for Device {
         let dims: [usize; 3] = [outer_size, inner_size, dim_size];
         let strides: [usize; 3] = [dim_size * inner_size, 1, inner_size];
         let info: Vec<usize> = dims.iter().chain(strides.iter()).copied().collect();
-        let info_dev = dst.device.stream.clone_htod(&info)?;
+        let info_dev = dst.device.cached_htod(&info)?;
 
         let kname = kernel_name::<T>("fast_argmax");
         let func = dst.device.get_func(&kname, PTXModule::Reduce)?;
@@ -1493,7 +1678,7 @@ impl crate::Backend for Device {
         let dims: [usize; 3] = [outer_size, inner_size, dim_size];
         let strides: [usize; 3] = [dim_size * inner_size, 1, inner_size];
         let info: Vec<usize> = dims.iter().chain(strides.iter()).copied().collect();
-        let info_dev = dst.device.stream.clone_htod(&info)?;
+        let info_dev = dst.device.cached_htod(&info)?;
 
         let kname = kernel_name::<T>("fast_sum");
         let func = dst.device.get_func(&kname, PTXModule::Reduce)?;
@@ -1649,7 +1834,7 @@ impl crate::Backend for Device {
                 .chain(rhs_strides.iter())
                 .copied()
                 .collect();
-            let info_dev = dst.device.stream.clone_htod(&info)?;
+            let info_dev = dst.device.cached_htod(&info)?;
 
             let kname = format!("broadcast_{}_strided_{}", op_name, T::DTYPE.cuda_name());
             let func = dst.device.get_func(&kname, PTXModule::Broadcast)?;

--- a/xn-core/tests/cuda_graph_tests.rs
+++ b/xn-core/tests/cuda_graph_tests.rs
@@ -1,0 +1,157 @@
+#![cfg(feature = "cuda")]
+
+//! CUDA-graph capture tests. These exercise the record/capture/replay flow of
+//! `Device::capture_record_begin` / `capture_begin` / `CaptureGraph::launch`
+//! and the host-upload cache backing it, and only run on CUDA-enabled hosts.
+
+use xn::{D, Result, Tensor, cuda_backend::Device};
+
+fn get_device() -> Device {
+    Device::new(0).expect("Failed to initialize CUDA device")
+}
+
+const B: usize = 2;
+const R: usize = 3;
+const C: usize = 4;
+
+/// The workload under capture: reads `input` (B, R, C), writes `out_sum`
+/// (B, C, 1) and `out_idx` (B, C) in place. It deliberately uses ops whose
+/// CUDA kernels upload host data internally — the strided copy behind
+/// `contiguous`, the shape descriptors of the reductions and of the broadcast
+/// — plus an explicit in-body `from_vec` constant. Those uploads are what the
+/// record/replay cache turns into capture-legal device-to-device copies.
+fn body(
+    input: &Tensor<f32, Device>,
+    out_sum: &Tensor<f32, Device>,
+    out_idx: &Tensor<i64, Device>,
+    bias: &[f32],
+    device: &Device,
+) -> Result<()> {
+    let x = input.transpose(1, 2)?.contiguous()?; // (B, C, R)
+    let bias = Tensor::from_vec(bias.to_vec(), R, device)?;
+    let x = x.broadcast_add(&bias)?;
+    out_sum.copy_(&x.sum_keepdim([2])?)?;
+    out_idx.copy_(&x.argmax(D::Minus1)?)?;
+    Ok(())
+}
+
+/// Host-side reference for [`body`].
+fn expected(input: &[f32], bias: &[f32]) -> (Vec<f32>, Vec<i64>) {
+    let mut sums = vec![0f32; B * C];
+    let mut idxs = vec![0i64; B * C];
+    for b in 0..B {
+        for c in 0..C {
+            let mut sum = 0f32;
+            let (mut best, mut best_r) = (f32::NEG_INFINITY, 0i64);
+            for r in 0..R {
+                let v = input[b * R * C + r * C + c] + bias[r];
+                sum += v;
+                if v > best {
+                    best = v;
+                    best_r = r as i64;
+                }
+            }
+            sums[b * C + c] = sum;
+            idxs[b * C + c] = best_r;
+        }
+    }
+    (sums, idxs)
+}
+
+fn check(
+    out_sum: &Tensor<f32, Device>,
+    out_idx: &Tensor<i64, Device>,
+    input: &[f32],
+    bias: &[f32],
+) -> Result<()> {
+    let (sums, idxs) = expected(input, bias);
+    assert_eq!(out_sum.to_vec()?, sums);
+    assert_eq!(out_idx.to_vec()?, idxs);
+    Ok(())
+}
+
+#[test]
+fn test_capture_replay() -> Result<()> {
+    let device = get_device();
+    let bias = [0.25f32, -1.5, 3.0];
+    let input_v: Vec<f32> = (0..B * R * C).map(|i| (i as f32) * 0.5 - 3.0).collect();
+    let input = Tensor::from_vec(input_v.clone(), (B, R, C), &device)?;
+    let out_sum: Tensor<f32, Device> = Tensor::zeros((B, C, 1), &device)?;
+    let out_idx: Tensor<i64, Device> = Tensor::zeros((B, C), &device)?;
+
+    // Record pass: runs normally and populates the upload cache.
+    device.capture_record_begin()?;
+    let res = body(&input, &out_sum, &out_idx, &bias, &device);
+    device.capture_record_end()?;
+    res?;
+    assert!(device.capture_cache_len() > 0, "record pass cached no uploads");
+    check(&out_sum, &out_idx, &input_v, &bias)?;
+
+    // Capture pass: records the graph without executing it.
+    out_sum.fill_(0.0)?;
+    out_idx.fill_(0)?;
+    device.capture_begin()?;
+    let res = body(&input, &out_sum, &out_idx, &bias, &device);
+    if res.is_err() {
+        device.capture_abort();
+    }
+    res?;
+    let graph = device.capture_end()?;
+    assert!(out_sum.to_vec()?.iter().all(|&x| x == 0.0), "capture must not execute");
+
+    // Replay computes.
+    graph.launch()?;
+    check(&out_sum, &out_idx, &input_v, &bias)?;
+
+    // Replays observe in-place refreshes of the input buffer.
+    for step in 1..4 {
+        let input_v: Vec<f32> =
+            (0..B * R * C).map(|i| ((i * step) as f32) * 0.25 - step as f32).collect();
+        input.copy_(&Tensor::from_vec(input_v.clone(), (B, R, C), &device)?)?;
+        graph.launch()?;
+        check(&out_sum, &out_idx, &input_v, &bias)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn test_capture_unrecorded_upload_fails() -> Result<()> {
+    let device = get_device();
+    let input_v: Vec<f32> = (0..B * R * C).map(|i| i as f32).collect();
+    let input = Tensor::from_vec(input_v, (B, R, C), &device)?;
+    let out_sum: Tensor<f32, Device> = Tensor::zeros((B, C, 1), &device)?;
+    let out_idx: Tensor<i64, Device> = Tensor::zeros((B, C), &device)?;
+
+    device.capture_record_begin()?;
+    let res = body(&input, &out_sum, &out_idx, &[1.0, 2.0, 3.0], &device);
+    device.capture_record_end()?;
+    res?;
+
+    // The bias differs from the record pass, so its `from_vec` content was
+    // never recorded and the capture must fail rather than fall back to a
+    // pageable host copy.
+    device.capture_begin()?;
+    let res = body(&input, &out_sum, &out_idx, &[4.0, 5.0, 6.0], &device);
+    device.capture_abort();
+    let err = res.expect_err("capturing an unrecorded upload should fail");
+    assert!(err.to_string().contains("unrecorded content"), "unexpected error: {err}");
+
+    // The device stays usable after the aborted capture.
+    let t = Tensor::from_vec(vec![1.0f32, 2.0], 2, &device)?;
+    assert_eq!(t.add(&t)?.to_vec()?, [2.0, 4.0]);
+    Ok(())
+}
+
+#[test]
+fn test_capture_mode_bookkeeping() -> Result<()> {
+    let device = get_device();
+    device.capture_record_begin()?;
+    assert!(device.capture_record_begin().is_err(), "nested record must fail");
+    let _: Tensor<f32, Device> = Tensor::from_vec(vec![1.0, 2.0, 3.0], 3, &device)?;
+    device.capture_record_end()?;
+    assert!(device.capture_record_end().is_err(), "unbalanced record end must fail");
+    assert!(device.capture_cache_len() > 0);
+    device.capture_cache_clear();
+    assert_eq!(device.capture_cache_len(), 0);
+    Ok(())
+}

--- a/xn-flash-attn/Cargo.toml
+++ b/xn-flash-attn/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["science"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-xn = { path = "../xn-core", features = ["cuda"], version = "0.2.0" }
+xn = { path = "../xn-core", features = ["cuda"], version = "0.2.1" }
 cudarc = { version = "0.19.4", features = ["driver"], default-features = false }
 half = { version = "2.7.1", features = ["num-traits"] }
 


### PR DESCRIPTION
Expose a record/capture/replay API on Device for capturing a fixed workload into a replayable CUDA graph:

- capture_record_begin/end: run the workload once while recording every internal host->device upload (kernel shape/stride descriptors, from_vec contents) into a device-side cache keyed by content.
- capture_begin/end -> CaptureGraph, capture_abort: capture the same workload into a graph; the cached uploads are served as in-capture allocations filled by device-to-device copies, since a pageable host copy is illegal while a stream is capturing. Unrecorded content is a hard error rather than a silent fallback.
- CaptureGraph::launch replays the captured kernels against the buffer addresses they were captured with: refresh long-lived input tensors in place, launch, read the outputs.

Two device-level changes make capture possible at all:
- The device now uses a proper stream instead of the legacy NULL default stream, which cannot be captured (CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED).
- Event tracking is disabled: creating a stream flips cudarc into multi-stream mode, whose per-slice event waits reference pre-capture events and fail capture with CUDA_ERROR_STREAM_CAPTURE_ISOLATION. All work runs on the single device stream, so stream order already synchronizes every use — this matches the effective behavior of the legacy stream (num_streams == 0 recorded no events either).

Motivation: the xn-moshi TTS depformer (32 codebook slices x 4 layers, ~3.8k kernel launches per step) is launch-bound; replaying it as one graph takes worker-level RTF from 1.87x to 2.09x per stream and aggregate throughput from 25x to 31x realtime at batch 16 on an RTX 4080 SUPER, with the depformer phase GPU utilization going from 35% to 76%.

Tests in tests/cuda_graph_tests.rs (CUDA hosts only) cover the record->capture->replay flow with in-place input refreshes, the capture-does-not-execute semantics, the unrecorded-upload failure path with device recovery after capture_abort, and the mode bookkeeping.


Claude-Session: https://claude.ai/code/session_015aVV7bShoQcNo3K33DGxAC