### PR TITLE
Add an XLA/PJRT backend with lazy graph capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +158,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.3",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bindgen_cuda"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +231,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +278,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,7 +313,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -261,6 +338,27 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
 
 [[package]]
 name = "clap"
@@ -370,6 +468,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +577,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cudarc"
@@ -557,6 +680,17 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -919,6 +1053,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,8 +1081,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1105,6 +1260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,10 +1429,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1311,6 +1493,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
 ]
 
 [[package]]
@@ -1582,7 +1774,7 @@ dependencies = [
  "log",
  "num-traits",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
@@ -1784,10 +1976,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1885,6 +2100,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "primal-check"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,7 +2150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1970,13 +2195,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1986,8 +2217,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -2046,7 +2283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -2161,6 +2398,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustfft"
@@ -2322,6 +2565,28 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2792,7 +3057,7 @@ dependencies = [
  "esaxx-rs",
  "getrandom 0.3.4",
  "indicatif 0.17.11",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -2936,6 +3201,12 @@ dependencies = [
  "num-integer",
  "strength_reduce",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -3220,7 +3491,7 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
@@ -3598,6 +3869,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xla"
+version = "0.3.2"
+source = "git+https://github.com/LaurentMazare/xla-rs?branch=pjrt-send-sync#090153969e12bd913be76410f18c99564cbdda1d"
+dependencies = [
+ "bindgen",
+ "cc",
+ "libc",
+ "num-derive",
+ "num-traits",
+ "thiserror 1.0.69",
+ "zip",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3636,6 +3921,7 @@ dependencies = [
  "tracing-chrome",
  "tracing-subscriber",
  "wgpu",
+ "xla",
  "yoke",
 ]
 
@@ -3762,7 +4048,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3871,7 +3871,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 [[package]]
 name = "xla"
 version = "0.3.2"
-source = "git+https://github.com/LaurentMazare/xla-rs?branch=pjrt-send-sync#090153969e12bd913be76410f18c99564cbdda1d"
+source = "git+https://github.com/LaurentMazare/xla-rs#8cd9f3e1c4ffc3c52df9185005611320c7594fd5"
 dependencies = [
  "bindgen",
  "cc",

--- a/xn-core/Cargo.toml
+++ b/xn-core/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 wgpu = { workspace = true, optional = true }
+xla = { git = "https://github.com/LaurentMazare/xla-rs", branch = "pjrt-send-sync", optional = true }
 yoke = { workspace = true }
 
 [dev-dependencies]
@@ -57,6 +58,7 @@ cuda = ["dep:cudarc", "dep:bindgen_cuda"]
 metal = ["dep:metal"]
 vulkan = ["dep:ash"]
 webgpu = ["dep:wgpu", "dep:pollster"]
+xla = ["dep:xla"]
 
 [[example]]
 name = "mimi"
@@ -69,6 +71,10 @@ required-features = ["audio"]
 [[example]]
 name = "basic_cuda"
 required-features = ["cuda"]
+
+[[example]]
+name = "backend_bench"
+required-features = ["cuda", "xla"]
 
 [[example]]
 name = "basic_vulkan"

--- a/xn-core/Cargo.toml
+++ b/xn-core/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 wgpu = { workspace = true, optional = true }
-xla = { git = "https://github.com/LaurentMazare/xla-rs", branch = "pjrt-send-sync", optional = true }
+xla = { git = "https://github.com/LaurentMazare/xla-rs", optional = true }
 yoke = { workspace = true }
 
 [dev-dependencies]

--- a/xn-core/examples/backend_bench.rs
+++ b/xn-core/examples/backend_bench.rs
@@ -1,0 +1,322 @@
+//! Benchmark the native CUDA backend against the XLA backend on the same GPU.
+//!
+//! Run with:
+//!   cargo run --release --features cuda,xla --example backend_bench -- \
+//!     --bench matmul --backend cuda --dtype bf16
+//!
+//! Workloads:
+//! - matmul:        C = A x B^T with A=[M, K], B=[N, K] (decode-shaped gemm)
+//! - llama-prefill: SmolLM-135M forward over a fixed-length prompt, no cache
+//!                  (static shapes: the xla executable cache gets hits)
+//! - llama-decode:  SmolLM-135M autoregressive decode with a growing kv-cache
+//!                  (shapes change every step: worst case for eager xla)
+//! - mimi-encode:   Mimi audio tokenizer, streaming encode of 1920-sample
+//!                  chunks (static shapes per step)
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+use std::time::Instant;
+use xn::models::llama::{Config, KvCache, Llama};
+use xn::nn::VB;
+use xn::{Backend, Tensor};
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Bench {
+    Matmul,
+    LlamaPrefill,
+    LlamaDecode,
+    MimiEncode,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum BackendArg {
+    Cuda,
+    Xla,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum DtypeArg {
+    F32,
+    F16,
+    Bf16,
+}
+
+#[derive(Parser, Debug, Clone, Copy)]
+#[command(about = "Benchmark native cuda vs xla backends")]
+struct Args {
+    #[arg(long, value_enum)]
+    bench: Bench,
+
+    #[arg(long, value_enum)]
+    backend: BackendArg,
+
+    #[arg(long, value_enum, default_value_t = DtypeArg::F32)]
+    dtype: DtypeArg,
+
+    /// Tokens to generate in llama-decode.
+    #[arg(long, default_value_t = 64)]
+    tokens: usize,
+
+    /// Prompt length for llama-prefill.
+    #[arg(long, default_value_t = 128)]
+    prefill: usize,
+
+    /// Iterations for matmul / llama-prefill / mimi chunks.
+    #[arg(long, default_value_t = 200)]
+    iters: usize,
+
+    /// Preallocated kv-cache capacity for llama-decode (0 = growing cache).
+    #[arg(long, default_value_t = 0)]
+    kv_cap: usize,
+
+    /// Warmup iterations.
+    #[arg(long, default_value_t = 20)]
+    warmup: usize,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    match args.backend {
+        BackendArg::Cuda => {
+            let dev = xn::cuda_backend::Device::new(0)?;
+            unsafe {
+                dev.disable_event_tracking();
+            }
+            println!("backend: cuda (native)");
+            dispatch(args, dev)
+        }
+        BackendArg::Xla => {
+            let dev = xn::xla_backend::Device::new(0)?;
+            println!("backend: xla ({})", dev.platform_name());
+            dispatch(args, dev)
+        }
+    }
+}
+
+fn dispatch<B: Backend>(args: Args, dev: B) -> Result<()> {
+    match args.dtype {
+        DtypeArg::F32 => run::<f32, B>(args, dev),
+        DtypeArg::F16 => run::<half::f16, B>(args, dev),
+        DtypeArg::Bf16 => run::<half::bf16, B>(args, dev),
+    }
+}
+
+fn run<T: xn::WithDTypeF, B: Backend>(args: Args, dev: B) -> Result<()> {
+    println!("dtype: {:?}", T::DTYPE);
+    match args.bench {
+        Bench::Matmul => bench_matmul::<T, B>(args, dev),
+        Bench::LlamaPrefill => bench_llama_prefill::<T, B>(args, dev),
+        Bench::LlamaDecode => bench_llama_decode::<T, B>(args, dev),
+        Bench::MimiEncode => bench_mimi_encode(args, dev),
+    }
+}
+
+fn random_vec<T: xn::WithDTypeF>(n: usize, seed: u64) -> Vec<T> {
+    let mut s = seed;
+    (0..n)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            T::from_f32((s & 0xFFFF) as f32 / 65535.0 * 2.0 - 1.0)
+        })
+        .collect()
+}
+
+fn stats(times: &[f64]) -> (f64, f64, f64) {
+    let mut sorted = times.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median = sorted[sorted.len() / 2];
+    let min = sorted[0];
+    let max = sorted[sorted.len() - 1];
+    (median, min, max)
+}
+
+// =========================================================================
+// matmul
+// =========================================================================
+
+fn bench_matmul<T: xn::WithDTypeF, B: Backend>(args: Args, dev: B) -> Result<()> {
+    const M: usize = 32;
+    const K: usize = 2048;
+    const N: usize = 11264;
+    println!("matmul: A=[{M}, {K}] x B^T=[{N}, {K}] -> C=[{M}, {N}]");
+
+    let a: Tensor<T, B> = Tensor::from_vec(random_vec::<T>(M * K, 42), (M, K), &dev)?;
+    let b: Tensor<T, B> = Tensor::from_vec(random_vec::<T>(N * K, 123), (N, K), &dev)?;
+
+    // Synchronize inside the loop: with a lazy backend, dropping the result
+    // without a sync would skip the computation entirely.
+    for _ in 0..args.warmup {
+        let c = a.matmul_t(&b)?;
+        dev.synchronize()?;
+        drop(c);
+    }
+
+    let t0 = Instant::now();
+    for _ in 0..args.iters {
+        let c = a.matmul_t(&b)?;
+        dev.synchronize()?;
+        drop(c);
+    }
+    let elapsed = t0.elapsed().as_secs_f64();
+    let us = elapsed * 1e6 / args.iters as f64;
+    let tflops = 2.0 * (M * N * K) as f64 * args.iters as f64 / elapsed / 1e12;
+    println!("{} iters | {us:.1} us/iter | {tflops:.2} TFLOP/s", args.iters);
+    Ok(())
+}
+
+// =========================================================================
+// llama
+// =========================================================================
+
+fn smol_lm_weights() -> Result<std::path::PathBuf> {
+    use hf_hub::{Repo, RepoType, api::sync::Api};
+    let api = Api::new()?;
+    let repo = api.repo(Repo::new("HuggingFaceTB/SmolLM-135M".to_string(), RepoType::Model));
+    repo.get("model.safetensors").context("model.safetensors not found")
+}
+
+fn load_smol_lm<T: xn::WithDTypeF, B: Backend>(dev: &B) -> Result<Llama<T, B>> {
+    let path = smol_lm_weights()?;
+    let vb = VB::load(&[path], dev.clone())?;
+    let model = Llama::load(&vb.root(), &Config::smol_lm_135m())?;
+    Ok(model)
+}
+
+fn bench_llama_prefill<T: xn::WithDTypeF, B: Backend>(args: Args, dev: B) -> Result<()> {
+    println!("llama-prefill: SmolLM-135M, prompt len {}, no kv-cache", args.prefill);
+    let model = load_smol_lm::<T, B>(&dev)?;
+    let tokens: Vec<u32> = (0..args.prefill).map(|i| 1000 + (i as u32 % 1000)).collect();
+
+    for _ in 0..args.warmup.min(5) {
+        let (_logits, _kv) = model.forward(&tokens, 0, None)?;
+        dev.synchronize()?;
+    }
+
+    let mut times = Vec::with_capacity(args.iters);
+    let t_all = Instant::now();
+    for _ in 0..args.iters {
+        let t0 = Instant::now();
+        let (_logits, _kv) = model.forward(&tokens, 0, None)?;
+        dev.synchronize()?;
+        times.push(t0.elapsed().as_secs_f64() * 1e3);
+    }
+    let elapsed = t_all.elapsed().as_secs_f64();
+    let (median, min, max) = stats(&times);
+    let tok_s = args.prefill as f64 * args.iters as f64 / elapsed;
+    println!(
+        "{} iters | median {median:.2} ms | min {min:.2} ms | max {max:.2} ms | {tok_s:.0} tok/s",
+        args.iters
+    );
+    Ok(())
+}
+
+fn bench_llama_decode<T: xn::WithDTypeF, B: Backend>(args: Args, dev: B) -> Result<()> {
+    println!(
+        "llama-decode: SmolLM-135M, 16-token prompt, {} decode steps, kv-cache: {}",
+        args.tokens,
+        if args.kv_cap == 0 { "growing".to_string() } else { format!("fixed[{}]", args.kv_cap) },
+    );
+    let model = load_smol_lm::<T, B>(&dev)?;
+    let prompt: Vec<u32> = (0..16).map(|i| 1000 + i as u32).collect();
+
+    let mut kv_cache: Option<KvCache<T, B>> = if args.kv_cap == 0 {
+        None
+    } else {
+        anyhow::ensure!(16 + args.tokens + 1 <= args.kv_cap, "kv-cap too small");
+        Some(KvCache::fixed(&Config::smol_lm_135m(), 1, args.kv_cap, &dev)?)
+    };
+    let mut prefill_done = false;
+    let mut generated: Vec<u32> = Vec::new();
+    let mut pos = 0;
+    let mut last_token = *prompt.last().unwrap();
+    let mut prefill_ms = 0f64;
+    let mut times = Vec::with_capacity(args.tokens);
+
+    for step in 0..=args.tokens {
+        let input: Vec<u32> = if !prefill_done { prompt.clone() } else { vec![last_token] };
+        prefill_done = true;
+        let t0 = Instant::now();
+        let (logits, new_kv) = model.forward(&input, pos, kv_cache.as_ref())?;
+        // Greedy sampling on the host; the transfer also acts as a sync point.
+        let logits = logits.to::<f32>()?.to_vec()?;
+        let elapsed = t0.elapsed().as_secs_f64() * 1e3;
+        kv_cache = Some(new_kv);
+        pos += input.len();
+        let vocab = logits.len() / input.len();
+        let last = &logits[logits.len() - vocab..];
+        last_token = last
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, _)| i as u32)
+            .unwrap_or(0);
+        generated.push(last_token);
+        if step == 0 {
+            prefill_ms = elapsed;
+        } else {
+            times.push(elapsed);
+        }
+    }
+
+    println!("first tokens: {:?}", &generated[..generated.len().min(8)]);
+    let (median, min, max) = stats(&times);
+    let total: f64 = times.iter().sum();
+    let tok_s = times.len() as f64 / (total / 1e3);
+    println!(
+        "prefill {prefill_ms:.1} ms | {} steps | median {median:.2} ms | min {min:.2} ms | max {max:.2} ms | {tok_s:.1} tok/s",
+        times.len()
+    );
+    Ok(())
+}
+
+// =========================================================================
+// mimi
+// =========================================================================
+
+fn bench_mimi_encode<B: Backend>(args: Args, dev: B) -> Result<()> {
+    use hf_hub::{Repo, RepoType, api::sync::Api};
+    use xn::models::mimi::{Config as MimiConfig, Mimi, StreamMask, StreamTensor};
+
+    println!("mimi-encode: streaming encode, 1920-sample chunks (f32 model)");
+    let api = Api::new()?;
+    let repo = api.repo(Repo::new("kyutai/moshiko-candle-q8".to_string(), RepoType::Model));
+    let model_path = repo
+        .get("tokenizer-e351c8d8-checkpoint125.safetensors")
+        .context("mimi weights not found")?;
+    let vb = VB::load(&[model_path], dev.clone())?;
+    let config = MimiConfig::v0_1_no_weight_norm(Some(8));
+    let mut model: Mimi<f32, B> = Mimi::load(&vb.root(), config, &dev)?;
+    model.reset_state();
+    let mask = StreamMask::empty();
+
+    const CHUNK: usize = 1920;
+    let pcm = random_vec::<f32>(CHUNK, 42);
+
+    // The streaming transformer inside mimi keeps a kv-cache that grows until
+    // it reaches its fixed context (250 frames), so shapes only stabilize
+    // after ~250 chunks: use `--warmup 260` or more to measure steady state.
+    let mut times = Vec::with_capacity(args.iters);
+    for it in 0..args.warmup + args.iters {
+        let audio: Tensor<f32, B> = Tensor::from_vec(pcm.clone(), (1, 1, CHUNK), &dev)?;
+        let t0 = Instant::now();
+        let codes = model.encode_step(&StreamTensor::from_tensor(audio), &mask)?;
+        if let Some(codes) = codes.as_option() {
+            let _v = codes.to_vec()?;
+        }
+        dev.synchronize()?;
+        if it >= args.warmup {
+            times.push(t0.elapsed().as_secs_f64() * 1e3);
+        }
+    }
+
+    let (median, min, max) = stats(&times);
+    // Each 1920-sample chunk is 80ms of 24kHz audio.
+    println!(
+        "{} chunks | median {median:.2} ms | min {min:.2} ms | max {max:.2} ms | rtf {:.1}x",
+        times.len(),
+        80.0 / median,
+    );
+    Ok(())
+}

--- a/xn-core/src/lib.rs
+++ b/xn-core/src/lib.rs
@@ -55,6 +55,11 @@ pub mod webgpu_backend;
 #[cfg(feature = "webgpu")]
 pub use webgpu_backend::Device as WebGpuDevice;
 
+#[cfg(feature = "xla")]
+pub mod xla_backend;
+#[cfg(feature = "xla")]
+pub use xla_backend::Device as XlaDevice;
+
 pub fn with_avx() -> bool {
     cfg!(target_feature = "avx")
 }

--- a/xn-core/src/models/llama.rs
+++ b/xn-core/src/models/llama.rs
@@ -149,6 +149,7 @@ impl<T: WithDTypeF, B: Backend> Attention<T, B> {
         sin: &Tensor<T, B>,
         pos: usize,
         kv_cache: Option<(&Tensor<T, B>, &Tensor<T, B>)>,
+        fixed_cache: bool,
     ) -> Result<(Tensor<T, B>, Tensor<T, B>, Tensor<T, B>)> {
         let (b, seq_len, _hidden) = x.dims3()?;
 
@@ -173,6 +174,15 @@ impl<T: WithDTypeF, B: Backend> Attention<T, B> {
 
         // Handle KV cache - cache BEFORE repeat_kv to save memory
         let (k_cache, v_cache, k, v) = match kv_cache {
+            Some((prev_k, prev_v)) if fixed_cache => {
+                // Preallocated cache: write the new keys/values in place at
+                // `pos` and attend over the whole (fixed-size) cache. The
+                // causality mask hides both future and not-yet-written
+                // positions, and shapes stay identical across decoding steps.
+                prev_k.slice_set(&k, 2, pos)?;
+                prev_v.slice_set(&v, 2, pos)?;
+                (prev_k.clone(), prev_v.clone(), prev_k.clone(), prev_v.clone())
+            }
             Some((prev_k, prev_v)) => {
                 let k_cat = Tensor::cat(&[prev_k, &k], 2)?;
                 let v_cat = Tensor::cat(&[prev_v, &v], 2)?;
@@ -304,11 +314,13 @@ impl<T: WithDTypeF, B: Backend> TransformerBlock<T, B> {
         sin: &Tensor<T, B>,
         pos: usize,
         kv_cache: Option<(&Tensor<T, B>, &Tensor<T, B>)>,
+        fixed_cache: bool,
     ) -> Result<(Tensor<T, B>, Tensor<T, B>, Tensor<T, B>)> {
         // Pre-norm architecture
         let residual = x;
         let x = self.input_layernorm.forward(x)?;
-        let (attn_out, k_cache, v_cache) = self.attn.forward(&x, cos, sin, pos, kv_cache)?;
+        let (attn_out, k_cache, v_cache) =
+            self.attn.forward(&x, cos, sin, pos, kv_cache, fixed_cache)?;
         let x = residual.add(&attn_out)?;
 
         let residual = &x;
@@ -331,6 +343,30 @@ pub struct Llama<T: WithDTypeF, B: Backend> {
 
 pub struct KvCache<T: WithDTypeF, B: Backend> {
     kvs: Vec<(Tensor<T, B>, Tensor<T, B>)>,
+    /// Sequence capacity when the cache is preallocated, `None` for a cache
+    /// growing by concatenation.
+    max_seq_len: Option<usize>,
+}
+
+impl<T: WithDTypeF, B: Backend> KvCache<T, B> {
+    /// Preallocate a fixed-capacity cache: keys and values are written in
+    /// place and attention always runs over `max_seq_len` positions, so the
+    /// tensor shapes are identical for every decoding step. This costs
+    /// compute proportional to the capacity but keeps shape-specialized
+    /// backends (e.g. xla) from recompiling at each step.
+    ///
+    /// Pass the cache to [`Llama::forward`] from the very first call on, and
+    /// keep `pos + tokens.len() <= max_seq_len`.
+    pub fn fixed(config: &Config, batch: usize, max_seq_len: usize, dev: &B) -> Result<Self> {
+        let shape = (batch, config.num_key_value_heads, max_seq_len, config.head_dim);
+        let mut kvs = Vec::with_capacity(config.num_hidden_layers);
+        for _ in 0..config.num_hidden_layers {
+            let k = Tensor::zeros(shape, dev)?;
+            let v = Tensor::zeros(shape, dev)?;
+            kvs.push((k, v));
+        }
+        Ok(Self { kvs, max_seq_len: Some(max_seq_len) })
+    }
 }
 
 impl<T: WithDTypeF, B: Backend> Llama<T, B> {
@@ -391,11 +427,18 @@ impl<T: WithDTypeF, B: Backend> Llama<T, B> {
         x = x.reshape((1, tokens.len(), ()))?;
 
         // Run through transformer layers
+        let max_seq_len = kv_caches.and_then(|c| c.max_seq_len);
         let mut kvs = Vec::with_capacity(self.layers.len());
         for (i, layer) in self.layers.iter().enumerate() {
             let kv_cache = kv_caches.map(|c| (&c.kvs[i].0, &c.kvs[i].1));
-            let (new_x, k_cache, v_cache) =
-                layer.forward(&x, &self.cos_cache, &self.sin_cache, pos, kv_cache)?;
+            let (new_x, k_cache, v_cache) = layer.forward(
+                &x,
+                &self.cos_cache,
+                &self.sin_cache,
+                pos,
+                kv_cache,
+                max_seq_len.is_some(),
+            )?;
             x = new_x;
             kvs.push((k_cache, v_cache));
         }
@@ -406,7 +449,7 @@ impl<T: WithDTypeF, B: Backend> Llama<T, B> {
         // LM head: (1, seq_len, hidden_size) -> (1, seq_len, vocab_size)
         let logits = self.lm_head.forward(&x)?;
 
-        Ok((logits, KvCache { kvs }))
+        Ok((logits, KvCache { kvs, max_seq_len }))
     }
 }
 

--- a/xn-core/src/xla_backend/lazy.rs
+++ b/xn-core/src/xla_backend/lazy.rs
@@ -1,0 +1,482 @@
+//! Lazy graph capture for the XLA backend.
+//!
+//! Backend operations do not execute immediately: each one appends a
+//! [`LazyNode`] holding the op descriptor and a build closure producing its
+//! XLA subgraph. Nodes form a DAG through their inputs (`Value::Node` edges),
+//! with materialized buffers as leaves. When a value is read on the host (or
+//! `synchronize` is called), the pending subgraph is flushed.
+//!
+//! Flushing hashes the graph structure into a key and then follows a hybrid
+//! policy: the first time a given structure is seen it is executed node by
+//! node (reusing per-op executables, so shape-churning workloads never pay
+//! for whole-graph compilation); when the same structure comes back, the
+//! whole graph is compiled into a single fused executable and cached, so
+//! steady-state loops replay one XLA program per step. Values that change
+//! per step without affecting shapes (offsets, positions) are passed as
+//! `Input::Scalar` and packed into a single side buffer at execution time,
+//! keeping them out of the structural key.
+use super::{Device, xerr};
+use crate::Result;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex, Weak};
+use xla::{ElementType, XlaBuilder, XlaOp};
+
+pub(super) type BuildFn = Box<dyn Fn(&XlaBuilder, &[XlaOp]) -> xla::Result<XlaOp> + Send + Sync>;
+
+/// The contents of a storage: either an actual device buffer or a node of
+/// the pending graph.
+#[derive(Clone)]
+pub(super) enum Value {
+    Buffer { buf: Arc<xla::PjRtBuffer>, len: usize, ty: ElementType },
+    Node(Arc<LazyNode>),
+}
+
+impl Value {
+    pub fn len(&self) -> usize {
+        match self {
+            Value::Buffer { len, .. } => *len,
+            Value::Node(n) => n.out_len,
+        }
+    }
+
+    pub fn ty(&self) -> ElementType {
+        match self {
+            Value::Buffer { ty, .. } => *ty,
+            Value::Node(n) => n.out_ty,
+        }
+    }
+}
+
+/// An input of a lazy node.
+pub(super) enum Input {
+    Value(Value),
+    /// A runtime scalar (offset, position). Packed into a single S64 side
+    /// buffer at execution time so that it does not affect the graph key.
+    Scalar(i64),
+}
+
+pub(super) struct LazyNode {
+    pub op: &'static str,
+    /// Structural key: shape parameters, dtypes and input lens/types.
+    pub key: Vec<i64>,
+    pub out_len: usize,
+    pub out_ty: ElementType,
+    pub state: Mutex<NodeState>,
+}
+
+pub(super) enum NodeState {
+    Pending {
+        inputs: Vec<Input>,
+        build: BuildFn,
+    },
+    Done(Arc<xla::PjRtBuffer>),
+    /// Transient state while a flush is executing this node.
+    Taken,
+}
+
+impl LazyNode {
+    pub fn done_buffer(&self) -> Option<Arc<xla::PjRtBuffer>> {
+        match &*self.state.lock().unwrap() {
+            NodeState::Done(b) => Some(b.clone()),
+            _ => None,
+        }
+    }
+
+    fn is_pending(&self) -> bool {
+        matches!(&*self.state.lock().unwrap(), NodeState::Pending { .. })
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum FusePolicy {
+    /// Compile a fused executable the first time a graph structure is seen.
+    Always,
+    /// Never fuse, always execute node by node.
+    Never,
+    /// Execute node by node on first sight, fuse from the second occurrence.
+    OnRepeat,
+}
+
+impl FusePolicy {
+    pub fn from_env() -> Self {
+        match std::env::var("XN_XLA_FUSE").as_deref() {
+            Ok("always") => Self::Always,
+            Ok("never") => Self::Never,
+            _ => Self::OnRepeat,
+        }
+    }
+}
+
+/// Force a value to a materialized buffer, flushing the pending graph if
+/// needed.
+pub(super) fn force(dev: &Device, value: &Value) -> Result<Arc<xla::PjRtBuffer>> {
+    match value {
+        Value::Buffer { buf, .. } => Ok(buf.clone()),
+        Value::Node(node) => {
+            if let Some(b) = node.done_buffer() {
+                return Ok(b);
+            }
+            flush(dev, std::slice::from_ref(node))?;
+            match node.done_buffer() {
+                Some(b) => Ok(b),
+                None => crate::bail!("xla: node {} not materialized after flush", node.op),
+            }
+        }
+    }
+}
+
+/// Flush every pending node currently registered on the device.
+pub(super) fn flush_all(dev: &Device) -> Result<()> {
+    let pending: Vec<Weak<LazyNode>> = std::mem::take(&mut *dev.inner.pending.lock().unwrap());
+    let roots: Vec<Arc<LazyNode>> =
+        pending.iter().filter_map(Weak::upgrade).filter(|n| n.is_pending()).collect();
+    if roots.is_empty() { Ok(()) } else { flush(dev, &roots) }
+}
+
+fn hash_str(s: &str) -> u64 {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    s.hash(&mut h);
+    h.finish()
+}
+
+/// How a node input maps onto the fused computation.
+enum Slot {
+    /// Leaf buffer, parameter index.
+    Param(usize),
+    /// Output of another pending node, topological index.
+    Node(usize),
+    /// Runtime scalar, index in the packed scalar buffer.
+    Scalar(usize),
+}
+
+pub(super) fn flush(dev: &Device, roots: &[Arc<LazyNode>]) -> Result<()> {
+    let inner = &dev.inner;
+    let _flush_guard = inner.flush_lock.lock().unwrap();
+
+    // Topological order (inputs before consumers) of the reachable pending
+    // nodes; iterative so deep chains cannot overflow the stack.
+    let mut topo: Vec<Arc<LazyNode>> = Vec::new();
+    let mut index: HashMap<*const LazyNode, usize> = HashMap::new();
+    {
+        enum Frame {
+            Enter(Arc<LazyNode>),
+            Exit(Arc<LazyNode>),
+        }
+        let mut stack: Vec<Frame> = roots.iter().rev().map(|n| Frame::Enter(n.clone())).collect();
+        let mut entered: HashSet<*const LazyNode> = HashSet::new();
+        while let Some(frame) = stack.pop() {
+            match frame {
+                Frame::Enter(n) => {
+                    let ptr = Arc::as_ptr(&n);
+                    if entered.contains(&ptr) {
+                        continue;
+                    }
+                    entered.insert(ptr);
+                    let children: Vec<Arc<LazyNode>> = match &*n.state.lock().unwrap() {
+                        NodeState::Pending { inputs, .. } => inputs
+                            .iter()
+                            .filter_map(|i| match i {
+                                Input::Value(Value::Node(c)) if c.is_pending() => Some(c.clone()),
+                                _ => None,
+                            })
+                            .collect(),
+                        _ => continue,
+                    };
+                    stack.push(Frame::Exit(n));
+                    for c in children {
+                        if !entered.contains(&Arc::as_ptr(&c)) {
+                            stack.push(Frame::Enter(c));
+                        }
+                    }
+                }
+                Frame::Exit(n) => {
+                    index.insert(Arc::as_ptr(&n), topo.len());
+                    topo.push(n);
+                }
+            }
+        }
+    }
+    if topo.is_empty() {
+        return Ok(());
+    }
+
+    // Count graph-internal references to decide which nodes must become
+    // outputs: a node referenced from outside the flushed graph (a live
+    // storage, or a pending node not part of this flush) has to be
+    // materialized; nodes only feeding other nodes of this graph are fused
+    // away.
+    let mut internal: HashMap<*const LazyNode, usize> = HashMap::new();
+    for n in topo.iter() {
+        if let NodeState::Pending { inputs, .. } = &*n.state.lock().unwrap() {
+            for i in inputs.iter() {
+                if let Input::Value(Value::Node(c)) = i {
+                    let ptr = Arc::as_ptr(c);
+                    if index.contains_key(&ptr) {
+                        *internal.entry(ptr).or_insert(0) += 1;
+                    }
+                }
+            }
+        }
+    }
+    let mut outputs: Vec<usize> = Vec::new();
+    for (i, n) in topo.iter().enumerate() {
+        let ptr = Arc::as_ptr(n);
+        // +1 accounts for the handle held by `topo` itself. This is
+        // conservative under concurrent clones, which can only add outputs.
+        let external = Arc::strong_count(n) > internal.get(&ptr).copied().unwrap_or(0) + 1;
+        if external {
+            outputs.push(i);
+        }
+    }
+
+    // Structural key and input slot assignment.
+    let mut key: Vec<u64> = Vec::new();
+    let mut params: Vec<(Arc<xla::PjRtBuffer>, usize, ElementType)> = Vec::new();
+    let mut param_slots: HashMap<*const xla::PjRtBuffer, usize> = HashMap::new();
+    let mut scalars: Vec<i64> = Vec::new();
+    let mut slots: Vec<Vec<Slot>> = Vec::with_capacity(topo.len());
+    let param_slot = |params: &mut Vec<(Arc<xla::PjRtBuffer>, usize, ElementType)>,
+                      param_slots: &mut HashMap<*const xla::PjRtBuffer, usize>,
+                      buf: &Arc<xla::PjRtBuffer>,
+                      len: usize,
+                      ty: ElementType|
+     -> usize {
+        let ptr = Arc::as_ptr(buf);
+        match param_slots.get(&ptr) {
+            Some(&slot) => slot,
+            None => {
+                let slot = params.len();
+                params.push((buf.clone(), len, ty));
+                param_slots.insert(ptr, slot);
+                slot
+            }
+        }
+    };
+    for n in topo.iter() {
+        key.push(hash_str(n.op));
+        key.extend(n.key.iter().map(|&v| v as u64));
+        let mut node_slots = Vec::new();
+        match &*n.state.lock().unwrap() {
+            NodeState::Pending { inputs, .. } => {
+                for i in inputs.iter() {
+                    let slot = match i {
+                        Input::Scalar(v) => {
+                            scalars.push(*v);
+                            Slot::Scalar(scalars.len() - 1)
+                        }
+                        Input::Value(Value::Buffer { buf, len, ty }) => {
+                            Slot::Param(param_slot(&mut params, &mut param_slots, buf, *len, *ty))
+                        }
+                        Input::Value(Value::Node(c)) => match index.get(&Arc::as_ptr(c)) {
+                            Some(&ci) => Slot::Node(ci),
+                            None => {
+                                // A node materialized by an earlier flush:
+                                // its buffer is a leaf.
+                                let buf = match c.done_buffer() {
+                                    Some(b) => b,
+                                    None => crate::bail!("xla: unmaterialized input {}", c.op),
+                                };
+                                Slot::Param(param_slot(
+                                    &mut params,
+                                    &mut param_slots,
+                                    &buf,
+                                    c.out_len,
+                                    c.out_ty,
+                                ))
+                            }
+                        },
+                    };
+                    match &slot {
+                        Slot::Param(i) => key.extend([1, *i as u64]),
+                        Slot::Node(i) => key.extend([2, *i as u64]),
+                        Slot::Scalar(i) => key.extend([3, *i as u64]),
+                    }
+                    node_slots.push(slot);
+                }
+            }
+            _ => crate::bail!("xla: node {} changed state during flush", n.op),
+        }
+        key.push(u64::MAX); // node separator
+        slots.push(node_slots);
+    }
+    for &o in outputs.iter() {
+        key.extend([4, o as u64]);
+    }
+
+    // Hybrid policy: run node by node the first time a structure shows up,
+    // compile the fused graph when it repeats.
+    let cached = inner.graph_cache.lock().unwrap().get(&key).cloned();
+    let exe = match cached {
+        Some(exe) => Some(exe),
+        None => {
+            let fuse = match inner.fuse_policy {
+                FusePolicy::Always => true,
+                FusePolicy::Never => false,
+                FusePolicy::OnRepeat => !inner.seen_graphs.lock().unwrap().insert(key.clone()),
+            };
+            if fuse {
+                let exe = compile_fused(dev, &topo, &slots, &outputs, &params, scalars.len())?;
+                inner.graph_cache.lock().unwrap().insert(key, exe.clone());
+                Some(exe)
+            } else {
+                None
+            }
+        }
+    };
+
+    match exe {
+        Some(exe) => execute_fused(dev, &exe, &topo, &outputs, &params, &scalars),
+        None => execute_eager(dev, &topo),
+    }
+}
+
+/// Build and compile the whole pending graph as a single computation whose
+/// root is the tuple of output nodes.
+fn compile_fused(
+    dev: &Device,
+    topo: &[Arc<LazyNode>],
+    slots: &[Vec<Slot>],
+    outputs: &[usize],
+    params: &[(Arc<xla::PjRtBuffer>, usize, ElementType)],
+    n_scalars: usize,
+) -> Result<Arc<xla::PjRtLoadedExecutable>> {
+    let b = XlaBuilder::new("fused");
+    let mut xparams = Vec::with_capacity(params.len());
+    for (i, (_, len, ty)) in params.iter().enumerate() {
+        let p = b.parameter(i as i64, *ty, &[*len as i64], &format!("p{i}")).map_err(xerr)?;
+        xparams.push(p);
+    }
+    let scalar_param = if n_scalars > 0 {
+        let p = b
+            .parameter(params.len() as i64, ElementType::S64, &[n_scalars as i64], "scalars")
+            .map_err(xerr)?;
+        Some(p)
+    } else {
+        None
+    };
+    let mut built: Vec<XlaOp> = Vec::with_capacity(topo.len());
+    for (n, node_slots) in topo.iter().zip(slots.iter()) {
+        let mut inputs = Vec::with_capacity(node_slots.len());
+        for slot in node_slots.iter() {
+            let op = match slot {
+                Slot::Param(i) => xparams[*i].clone(),
+                Slot::Node(i) => built[*i].clone(),
+                Slot::Scalar(i) => {
+                    let p = scalar_param.as_ref().expect("scalar param");
+                    // Shape [1], matching what the build closures expect.
+                    p.slice_in_dim(*i as i64, *i as i64 + 1, 1, 0).map_err(xerr)?
+                }
+            };
+            inputs.push(op);
+        }
+        let state = n.state.lock().unwrap();
+        let NodeState::Pending { build, .. } = &*state else {
+            crate::bail!("xla: node {} changed state during fusion", n.op)
+        };
+        let op = build(&b, &inputs).map_err(xerr)?;
+        drop(state);
+        built.push(op);
+    }
+    let outs: Vec<&XlaOp> = outputs.iter().map(|&o| &built[o]).collect();
+    let root = b.tuple(&outs).map_err(xerr)?;
+    let comp = b.build(&root).map_err(xerr)?;
+    let exe = dev.inner.client.compile(&comp).map_err(xerr)?;
+    Ok(Arc::new(exe))
+}
+
+fn execute_fused(
+    dev: &Device,
+    exe: &xla::PjRtLoadedExecutable,
+    topo: &[Arc<LazyNode>],
+    outputs: &[usize],
+    params: &[(Arc<xla::PjRtBuffer>, usize, ElementType)],
+    scalars: &[i64],
+) -> Result<()> {
+    let scalar_buf = if scalars.is_empty() {
+        None
+    } else {
+        let bytes: Vec<u8> = scalars.iter().flat_map(|v| v.to_le_bytes()).collect();
+        Some(dev.upload(ElementType::S64, &bytes, scalars.len())?)
+    };
+    let mut args: Vec<&xla::PjRtBuffer> = params.iter().map(|(b, _, _)| b.as_ref()).collect();
+    if let Some(sb) = scalar_buf.as_ref() {
+        args.push(sb);
+    }
+    let outs = exe.execute_b(&args).map_err(xerr)?;
+    let bufs: Vec<xla::PjRtBuffer> = outs.into_iter().flatten().collect();
+    if bufs.len() != outputs.len() {
+        crate::bail!(
+            "xla: fused execution returned {} buffers, expected {}",
+            bufs.len(),
+            outputs.len()
+        )
+    }
+    for (&o, buf) in outputs.iter().zip(bufs) {
+        *topo[o].state.lock().unwrap() = NodeState::Done(Arc::new(buf));
+    }
+    Ok(())
+}
+
+/// Execute the pending nodes one by one, compiling (or reusing) a small
+/// executable per node. This is the first-sight path of the hybrid policy:
+/// per-node executables are shared across steps even when the overall graph
+/// shape keeps changing.
+fn execute_eager(dev: &Device, topo: &[Arc<LazyNode>]) -> Result<()> {
+    for n in topo.iter() {
+        let state = std::mem::replace(&mut *n.state.lock().unwrap(), NodeState::Taken);
+        let NodeState::Pending { inputs, build } = state else {
+            crate::bail!("xla: node {} changed state during eager flush", n.op)
+        };
+        let mut args: Vec<Arc<xla::PjRtBuffer>> = Vec::with_capacity(inputs.len());
+        let mut meta: Vec<(usize, ElementType)> = Vec::with_capacity(inputs.len());
+        for i in inputs.iter() {
+            match i {
+                Input::Scalar(v) => {
+                    args.push(Arc::new(dev.upload(ElementType::S64, &v.to_le_bytes(), 1)?));
+                    meta.push((1, ElementType::S64));
+                }
+                Input::Value(Value::Buffer { buf, len, ty }) => {
+                    args.push(buf.clone());
+                    meta.push((*len, *ty));
+                }
+                Input::Value(Value::Node(c)) => {
+                    let buf = match c.done_buffer() {
+                        Some(b) => b,
+                        None => crate::bail!("xla: unmaterialized input {} of {}", c.op, n.op),
+                    };
+                    args.push(buf);
+                    meta.push((c.out_len, c.out_ty));
+                }
+            }
+        }
+        let cache_key = (n.op, n.key.clone());
+        let cached = dev.inner.node_cache.lock().unwrap().get(&cache_key).cloned();
+        let exe = match cached {
+            Some(exe) => exe,
+            None => {
+                let b = XlaBuilder::new(n.op);
+                let mut xops = Vec::with_capacity(meta.len());
+                for (i, (len, ty)) in meta.iter().enumerate() {
+                    let p = b
+                        .parameter(i as i64, *ty, &[*len as i64], &format!("p{i}"))
+                        .map_err(xerr)?;
+                    xops.push(p);
+                }
+                let root = build(&b, &xops).map_err(xerr)?;
+                let comp = b.build(&root).map_err(xerr)?;
+                let exe = Arc::new(dev.inner.client.compile(&comp).map_err(xerr)?);
+                dev.inner.node_cache.lock().unwrap().insert(cache_key, exe.clone());
+                exe
+            }
+        };
+        let arg_refs: Vec<&xla::PjRtBuffer> = args.iter().map(|a| a.as_ref()).collect();
+        let mut outs = exe.execute_b(&arg_refs).map_err(xerr)?;
+        let buf = match outs.pop().and_then(|mut r| r.pop()) {
+            Some(b) => b,
+            None => crate::bail!("xla: execution of {} returned no buffer", n.op),
+        };
+        *n.state.lock().unwrap() = NodeState::Done(Arc::new(buf));
+    }
+    Ok(())
+}

--- a/xn-core/src/xla_backend/mod.rs
+++ b/xn-core/src/xla_backend/mod.rs
@@ -1,0 +1,1279 @@
+//! An XLA backend built on top of PJRT, with lazy graph capture.
+//!
+//! Storage lives on the PJRT device as rank-1 buffers, but operations do not
+//! execute immediately: they record nodes of a computation graph (see the
+//! [`lazy`] module) which is flushed when data is read back on the host or
+//! `synchronize` is called. Recurring graph structures are compiled into a
+//! single fused XLA executable and replayed, so steady-state inference loops
+//! pay one host round-trip per step; the first occurrence of a structure runs
+//! node by node with per-op executables, which keeps shape-changing workloads
+//! from recompiling whole graphs. Values that change per step without
+//! affecting shapes (offsets, positions) are runtime inputs rather than graph
+//! constants, keeping the caches hot in decoding loops.
+mod lazy;
+
+use crate::{BinaryOp, DType, Result, UnaryOp, WithDType, WithDTypeF};
+use lazy::{FusePolicy, Input, LazyNode, NodeState, Value};
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex, Weak};
+use xla::{ElementType, XlaBuilder, XlaOp};
+
+fn xerr(err: xla::Error) -> crate::Error {
+    crate::Error::wrap(err)
+}
+
+fn ety(dtype: DType) -> ElementType {
+    match dtype {
+        DType::F16 => ElementType::F16,
+        DType::BF16 => ElementType::Bf16,
+        DType::F32 => ElementType::F32,
+        DType::I64 => ElementType::S64,
+        DType::U8 => ElementType::U8,
+    }
+}
+
+fn dtype_key(dtype: DType) -> i64 {
+    match dtype {
+        DType::F16 => 0,
+        DType::BF16 => 1,
+        DType::F32 => 2,
+        DType::I64 => 3,
+        DType::U8 => 4,
+    }
+}
+
+fn unary_key(op: UnaryOp) -> [i64; 2] {
+    match op {
+        UnaryOp::Cos => [0, 0],
+        UnaryOp::Sin => [1, 0],
+        UnaryOp::Exp => [2, 0],
+        UnaryOp::Log => [3, 0],
+        UnaryOp::Neg => [4, 0],
+        UnaryOp::Sqr => [5, 0],
+        UnaryOp::Sqrt => [6, 0],
+        UnaryOp::Rsqrt => [7, 0],
+        UnaryOp::Abs => [8, 0],
+        UnaryOp::GeluErf => [9, 0],
+        UnaryOp::Elu { alpha } => [10, alpha.to_bits() as i64],
+        UnaryOp::Relu => [11, 0],
+        UnaryOp::Silu => [12, 0],
+        UnaryOp::Tanh => [13, 0],
+        UnaryOp::Sigmoid => [14, 0],
+    }
+}
+
+fn binary_key(op: BinaryOp) -> i64 {
+    match op {
+        BinaryOp::Add => 0,
+        BinaryOp::Sub => 1,
+        BinaryOp::Mul => 2,
+        BinaryOp::Div => 3,
+        BinaryOp::Maximum => 4,
+        BinaryOp::Minimum => 5,
+    }
+}
+
+type ExeCache<K> = Mutex<HashMap<K, Arc<xla::PjRtLoadedExecutable>>>;
+
+pub(crate) struct Inner {
+    client: xla::PjRtClient,
+    /// Per-op executables, used the first time a graph structure is seen.
+    node_cache: ExeCache<(&'static str, Vec<i64>)>,
+    /// Whole-graph fused executables keyed by graph structure.
+    graph_cache: ExeCache<Vec<u64>>,
+    /// Graph structures seen once (candidates for fusion on repeat).
+    seen_graphs: Mutex<HashSet<Vec<u64>>>,
+    /// Pending nodes, flushed by `synchronize` or when the graph gets large.
+    pending: Mutex<Vec<Weak<LazyNode>>>,
+    /// Serializes flushes.
+    flush_lock: Mutex<()>,
+    fuse_policy: FusePolicy,
+}
+
+/// Flush automatically once this many nodes are pending.
+const MAX_PENDING: usize = 4000;
+
+#[derive(Clone)]
+pub struct Device {
+    inner: Arc<Inner>,
+}
+
+impl std::fmt::Debug for Device {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "XlaDevice({})", self.inner.client.platform_name())
+    }
+}
+
+impl Device {
+    fn from_client(client: xla::PjRtClient) -> Self {
+        let inner = Inner {
+            client,
+            node_cache: Mutex::new(HashMap::new()),
+            graph_cache: Mutex::new(HashMap::new()),
+            seen_graphs: Mutex::new(HashSet::new()),
+            pending: Mutex::new(Vec::new()),
+            flush_lock: Mutex::new(()),
+            fuse_policy: FusePolicy::from_env(),
+        };
+        Self { inner: Arc::new(inner) }
+    }
+
+    /// Create a device for the best available PJRT platform (TPU, then GPU,
+    /// then CPU). The `_device_id` argument is currently ignored, PJRT picks
+    /// its default device.
+    pub fn new(_device_id: usize) -> Result<Self> {
+        let client = xla::PjRtClient::auto(/* force_cpu= */ false).map_err(xerr)?;
+        Ok(Self::from_client(client))
+    }
+
+    /// Create a device backed by the PJRT CPU client.
+    pub fn cpu() -> Result<Self> {
+        let client = xla::PjRtClient::cpu().map_err(xerr)?;
+        Ok(Self::from_client(client))
+    }
+
+    pub fn platform_name(&self) -> String {
+        self.inner.client.platform_name()
+    }
+
+    fn upload(&self, ty: ElementType, bytes: &[u8], len: usize) -> Result<xla::PjRtBuffer> {
+        self.inner.client.buffer_from_host_raw_bytes(ty, bytes, &[len], None).map_err(xerr)
+    }
+
+    /// A one-element buffer holding a runtime scalar of the storage dtype.
+    fn scalar_t<T: WithDType>(&self, v: T) -> Result<Input> {
+        let bytes = unsafe {
+            std::slice::from_raw_parts(&v as *const T as *const u8, std::mem::size_of::<T>())
+        };
+        let buf = self.upload(ety(T::DTYPE), bytes, 1)?;
+        Ok(Input::Value(Value::Buffer { buf: Arc::new(buf), len: 1, ty: ety(T::DTYPE) }))
+    }
+}
+
+pub struct Storage<T: WithDType> {
+    value: Value,
+    len: usize,
+    device: Device,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+fn arg<T: WithDType>(st: &Storage<T>) -> Input {
+    Input::Value(st.value.clone())
+}
+
+/// Record a lazy node: `build` produces the rank-1 result of length
+/// `out_len` from the rank-1 inputs, and runs when the graph is flushed.
+fn lazy_op(
+    dev: &Device,
+    op: &'static str,
+    key_extra: &[i64],
+    inputs: Vec<Input>,
+    out_len: usize,
+    out_dtype: DType,
+    build: impl Fn(&XlaBuilder, &[XlaOp]) -> xla::Result<XlaOp> + Send + Sync + 'static,
+) -> Result<Value> {
+    let mut key = Vec::with_capacity(key_extra.len() + inputs.len() * 2 + 2);
+    key.extend_from_slice(key_extra);
+    key.push(out_len as i64);
+    key.push(dtype_key(out_dtype));
+    for i in inputs.iter() {
+        match i {
+            Input::Scalar(_) => key.extend([-1, -1]),
+            Input::Value(v) => key.extend([v.len() as i64, v.ty().primitive_type() as i64]),
+        }
+    }
+    let node = Arc::new(LazyNode {
+        op,
+        key,
+        out_len,
+        out_ty: ety(out_dtype),
+        state: Mutex::new(NodeState::Pending { inputs, build: Box::new(build) }),
+    });
+    let value = Value::Node(node.clone());
+    let flush_now = {
+        let mut pending = dev.inner.pending.lock().unwrap();
+        pending.push(Arc::downgrade(&node));
+        pending.len() >= MAX_PENDING
+    };
+    if flush_now {
+        lazy::flush_all(dev)?;
+    }
+    Ok(value)
+}
+
+/// When an operation only writes the first `len` elements of a destination of
+/// `dst_len` elements, keep the destination tail unchanged by concatenating it
+/// back after the freshly computed prefix.
+fn splice(dst_p: &XlaOp, dst_len: usize, len: usize, prefix: XlaOp) -> xla::Result<XlaOp> {
+    if len == dst_len {
+        Ok(prefix)
+    } else {
+        let tail = dst_p.slice_in_dim(len as i64, dst_len as i64, 1, 0)?;
+        prefix.concat_in_dim(&[tail], 0)
+    }
+}
+
+/// Flat indices into a rank-1 array for an affine layout: for each position
+/// `(i_0, .., i_r)` of `dims`, the index is `base + sum_d i_d * strides[d]`,
+/// where `base` is a runtime scalar op (S64).
+fn affine_index(
+    b: &XlaBuilder,
+    base: &XlaOp,
+    dims: &[i64],
+    strides: &[usize],
+) -> xla::Result<XlaOp> {
+    let mut acc = base.broadcast(dims)?;
+    for (d, &stride) in strides.iter().enumerate() {
+        if stride == 0 || dims[d] == 1 {
+            continue;
+        }
+        let iota = b.iota(ElementType::S64, dims, d as i64)?;
+        let term = iota.mul_(&b.c0(stride as i64)?)?;
+        acc = acc.add_(&term)?;
+    }
+    Ok(acc)
+}
+
+/// Gather elements of a rank-1 array at the given (multi-dimensional) indices,
+/// the result has the shape of `indices`.
+fn gather_1d(src: &XlaOp, indices: &XlaOp) -> xla::Result<XlaOp> {
+    src.take(indices, 0)
+}
+
+/// A computation combining an old and an update scalar by keeping the update,
+/// used by scatter to overwrite the target elements.
+fn replace_computation(ty: ElementType) -> xla::Result<xla::XlaComputation> {
+    let b = XlaBuilder::new("replace");
+    let _old = b.parameter(0, ty, &[], "old")?;
+    let new = b.parameter(1, ty, &[], "new")?;
+    b.build(&new)
+}
+
+/// Scatter `updates` (rank-1, n elements) into `dst` (rank-1) at the flat
+/// positions given by `indices` (rank-1, n elements, S64).
+fn scatter_1d(
+    dst: &XlaOp,
+    indices: &XlaOp,
+    updates: &XlaOp,
+    ty: ElementType,
+) -> xla::Result<XlaOp> {
+    let n = match indices.array_shape()?.dims() {
+        [n] => *n,
+        _ => {
+            return Err(xla::Error::XlaError {
+                msg: "expected a rank-1 index array".to_string(),
+                backtrace: String::new(),
+            });
+        }
+    };
+    let indices = indices.reshape(&[n, 1])?;
+    let comp = replace_computation(ty)?;
+    dst.scatter(&indices, updates, &comp, &[], &[0], &[0], 1)
+}
+
+/// Convert to f32 for float computations that the cpu backend also performs
+/// in f32 (the `half` crate computes through f32 as well).
+fn to_f32(x: &XlaOp) -> xla::Result<XlaOp> {
+    x.convert(ElementType::F32.primitive_type())
+}
+
+fn from_f32(x: &XlaOp, dtype: DType) -> xla::Result<XlaOp> {
+    x.convert(ety(dtype).primitive_type())
+}
+
+fn build_unary(x: &XlaOp, op: UnaryOp, dtype: DType) -> xla::Result<XlaOp> {
+    let b = x.builder().clone();
+    let x = to_f32(x)?;
+    let res = match op {
+        UnaryOp::Cos => x.cos()?,
+        UnaryOp::Sin => x.sin()?,
+        UnaryOp::Exp => x.exp()?,
+        UnaryOp::Log => x.log()?,
+        UnaryOp::Neg => x.neg()?,
+        UnaryOp::Sqr => x.mul_(&x)?,
+        UnaryOp::Sqrt => x.sqrt()?,
+        UnaryOp::Rsqrt => x.rsqrt()?,
+        UnaryOp::Abs => x.abs()?,
+        UnaryOp::GeluErf => x.gelu_erf()?,
+        UnaryOp::Elu { alpha } => {
+            let zero = b.c0(0f32)?;
+            let alpha = b.c0(alpha)?;
+            let neg = x.exp()?.sub_(&b.c0(1f32)?)?.mul_(&alpha)?;
+            x.gt(&zero)?.select(&x, &neg)?
+        }
+        UnaryOp::Relu => x.max(&b.c0(0f32)?)?,
+        UnaryOp::Silu => x.silu()?,
+        UnaryOp::Tanh => x.tanh()?,
+        UnaryOp::Sigmoid => x.logistic()?,
+    };
+    from_f32(&res, dtype)
+}
+
+fn build_binary(lhs: &XlaOp, rhs: &XlaOp, op: BinaryOp) -> xla::Result<XlaOp> {
+    match op {
+        BinaryOp::Add => lhs.add_(rhs),
+        BinaryOp::Sub => lhs.sub_(rhs),
+        BinaryOp::Mul => lhs.mul_(rhs),
+        BinaryOp::Div => lhs.div_(rhs),
+        BinaryOp::Maximum => lhs.max(rhs),
+        BinaryOp::Minimum => lhs.min(rhs),
+    }
+}
+
+fn product(dims: &[usize]) -> usize {
+    dims.iter().product()
+}
+
+impl crate::Backend for Device {
+    type Storage<T: WithDType> = Storage<T>;
+
+    fn name(&self) -> String {
+        format!("xla-{}", self.platform_name())
+    }
+
+    fn synchronize(&self) -> Result<()> {
+        lazy::flush_all(self)
+    }
+
+    fn storage_len<T: WithDType>(storage: &Self::Storage<T>) -> usize {
+        storage.len
+    }
+
+    unsafe fn alloc_uninit<T: WithDType>(len: usize, dev: &Self) -> Result<Self::Storage<T>> {
+        // Allocation is a lazy zero-fill: it costs nothing until (unless)
+        // some operation actually reads the initial contents, and XLA removes
+        // it from fused graphs when every element gets overwritten.
+        let ty = ety(T::DTYPE);
+        let value = lazy_op(dev, "zeros", &[], vec![], len, T::DTYPE, move |b, _p| {
+            b.zero(ty)?.broadcast(&[len as i64])
+        })?;
+        Ok(Storage { value, len, device: dev.clone(), _phantom: Default::default() })
+    }
+
+    fn from_vec<T: WithDType>(v: Vec<T>, dev: &Self) -> Result<Self::Storage<T>> {
+        let len = v.len();
+        let bytes = unsafe {
+            std::slice::from_raw_parts(v.as_ptr() as *const u8, len * std::mem::size_of::<T>())
+        };
+        let buf = dev.upload(ety(T::DTYPE), bytes, len)?;
+        let value = Value::Buffer { buf: Arc::new(buf), len, ty: ety(T::DTYPE) };
+        Ok(Storage { value, len, device: dev.clone(), _phantom: Default::default() })
+    }
+
+    fn data<T: WithDType>(src: &Self::Storage<T>, len: usize) -> Result<std::borrow::Cow<'_, [T]>> {
+        let buffer = lazy::force(&src.device, &src.value)?;
+        let literal = buffer.to_literal_sync().map_err(xerr)?;
+        let mut bytes = vec![0u8; literal.size_bytes()];
+        literal.copy_untyped_to(&mut bytes).map_err(xerr)?;
+        let v = T::vec_from_le_bytes(&bytes[..len * std::mem::size_of::<T>()]);
+        Ok(std::borrow::Cow::Owned(v))
+    }
+
+    fn fill<T: WithDType>(dst: &mut Self::Storage<T>, elem: T, len: usize) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let inputs = vec![arg(dst), dev.scalar_t(elem)?];
+        dst.value =
+            lazy_op(&dev, "fill", &[len as i64], inputs, dst_len, T::DTYPE, move |_b, p| {
+                let v = p[1].reshape(&[])?.broadcast(&[len as i64])?;
+                splice(&p[0], dst_len, len, v)
+            })?;
+        Ok(())
+    }
+
+    fn rand_uniform(dst: &mut Self::Storage<f32>, len: usize, lo: f32, up: f32) -> Result<()> {
+        // Generate on the host: XLA's rng op inside a cached executable would
+        // replay the exact same values on every execution.
+        use rand::Rng;
+        let mut rng = rand::rng();
+        let v: Vec<f32> = (0..len).map(|_| rng.random::<f32>() * (up - lo) + lo).collect();
+        let src = Self::from_vec(v, &dst.device.clone())?;
+        Self::copy(dst, &src, len)
+    }
+
+    fn randn(dst: &mut Self::Storage<f32>, len: usize, mean: f32, std: f32) -> Result<()> {
+        use rand_distr::Distribution;
+        let distr = match rand_distr::Normal::<f32>::new(mean, std) {
+            Ok(d) => d,
+            Err(e) => crate::bail!("failed to create normal distribution for randn: {e}"),
+        };
+        let mut rng = rand::rng();
+        let v: Vec<f32> = (0..len).map(|_| distr.sample(&mut rng)).collect();
+        let src = Self::from_vec(v, &dst.device.clone())?;
+        Self::copy(dst, &src, len)
+    }
+
+    fn copy<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        len: usize,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let inputs = vec![arg(dst), arg(src)];
+        dst.value =
+            lazy_op(&dev, "copy", &[len as i64], inputs, dst_len, T::DTYPE, move |_b, p| {
+                let v = p[1].slice_in_dim(0, len as i64, 1, 0)?;
+                splice(&p[0], dst_len, len, v)
+            })?;
+        Ok(())
+    }
+
+    fn to_dtype<T: WithDType, U: WithDType>(
+        dst: &mut Self::Storage<U>,
+        src: &Self::Storage<T>,
+        len: usize,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let inputs = vec![arg(dst), arg(src)];
+        dst.value =
+            lazy_op(&dev, "to_dtype", &[len as i64], inputs, dst_len, U::DTYPE, move |_b, p| {
+                let v = p[1].slice_in_dim(0, len as i64, 1, 0)?;
+                let v = v.convert(ety(U::DTYPE).primitive_type())?;
+                splice(&p[0], dst_len, len, v)
+            })?;
+        Ok(())
+    }
+
+    fn inplace_unary<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        len: usize,
+        op: UnaryOp,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let [k0, k1] = unary_key(op);
+        let inputs = vec![arg(dst)];
+        dst.value = lazy_op(
+            &dev,
+            "inplace_unary",
+            &[len as i64, k0, k1],
+            inputs,
+            dst_len,
+            T::DTYPE,
+            move |_b, p| {
+                let v = p[0].slice_in_dim(0, len as i64, 1, 0)?;
+                let v = build_unary(&v, op, T::DTYPE)?;
+                splice(&p[0], dst_len, len, v)
+            },
+        )?;
+        Ok(())
+    }
+
+    fn unary<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        len: usize,
+        op: UnaryOp,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let [k0, k1] = unary_key(op);
+        let inputs = vec![arg(dst), arg(src)];
+        dst.value = lazy_op(
+            &dev,
+            "unary",
+            &[len as i64, k0, k1],
+            inputs,
+            dst_len,
+            T::DTYPE,
+            move |_b, p| {
+                let v = p[1].slice_in_dim(0, len as i64, 1, 0)?;
+                let v = build_unary(&v, op, T::DTYPE)?;
+                splice(&p[0], dst_len, len, v)
+            },
+        )?;
+        Ok(())
+    }
+
+    fn bin_assign<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        len: usize,
+        op: BinaryOp,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let inputs = vec![arg(dst), arg(src)];
+        dst.value = lazy_op(
+            &dev,
+            "bin_assign",
+            &[len as i64, binary_key(op)],
+            inputs,
+            dst_len,
+            T::DTYPE,
+            move |_b, p| {
+                let lhs = p[0].slice_in_dim(0, len as i64, 1, 0)?;
+                let rhs = p[1].slice_in_dim(0, len as i64, 1, 0)?;
+                let v = build_binary(&lhs, &rhs, op)?;
+                splice(&p[0], dst_len, len, v)
+            },
+        )?;
+        Ok(())
+    }
+
+    fn binary<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        lhs: &Self::Storage<T>,
+        rhs: &Self::Storage<T>,
+        len: usize,
+        op: BinaryOp,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let inputs = vec![arg(dst), arg(lhs), arg(rhs)];
+        dst.value = lazy_op(
+            &dev,
+            "binary",
+            &[len as i64, binary_key(op)],
+            inputs,
+            dst_len,
+            T::DTYPE,
+            move |_b, p| {
+                let lhs = p[1].slice_in_dim(0, len as i64, 1, 0)?;
+                let rhs = p[2].slice_in_dim(0, len as i64, 1, 0)?;
+                let v = build_binary(&lhs, &rhs, op)?;
+                splice(&p[0], dst_len, len, v)
+            },
+        )?;
+        Ok(())
+    }
+
+    fn scale_add<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        scale: T,
+        add: T,
+        len: usize,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let inputs = vec![arg(dst), arg(src), dev.scalar_t(scale)?, dev.scalar_t(add)?];
+        dst.value =
+            lazy_op(&dev, "scale_add", &[len as i64], inputs, dst_len, T::DTYPE, move |_b, p| {
+                let src = p[1].slice_in_dim(0, len as i64, 1, 0)?;
+                let scale = p[2].reshape(&[])?;
+                let add = p[3].reshape(&[])?;
+                let v = src.mul_(&scale)?.add_(&add)?;
+                splice(&p[0], dst_len, len, v)
+            })?;
+        Ok(())
+    }
+
+    fn transpose<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        dim1: usize,
+        dim2: usize,
+        dims: &[usize],
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let n = product(dims);
+        let dims_i64: Vec<i64> = dims.iter().map(|&d| d as i64).collect();
+        let mut key: Vec<i64> = vec![dim1 as i64, dim2 as i64];
+        key.extend(dims_i64.iter());
+        let inputs = vec![arg(dst), arg(src)];
+        dst.value = lazy_op(&dev, "transpose", &key, inputs, dst_len, T::DTYPE, move |_b, p| {
+            let v = p[1].slice_in_dim(0, n as i64, 1, 0)?.reshape(&dims_i64)?;
+            let v = v.swap_dims(dim1 as i64, dim2 as i64)?;
+            let v = v.reshape(&[n as i64])?;
+            splice(&p[0], dst_len, n, v)
+        })?;
+        Ok(())
+    }
+
+    fn copy2d<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        d1: usize,
+        d2: usize,
+        dst_s: usize,
+        src_s: usize,
+        dst_o: usize,
+        src_o: usize,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let ty = ety(T::DTYPE);
+        let key = [d1 as i64, d2 as i64, dst_s as i64, src_s as i64];
+        let inputs =
+            vec![arg(dst), arg(src), Input::Scalar(dst_o as i64), Input::Scalar(src_o as i64)];
+        dst.value = lazy_op(&dev, "copy2d", &key, inputs, dst_len, T::DTYPE, move |b, p| {
+            let dims = [d1 as i64, d2 as i64];
+            let n = (d1 * d2) as i64;
+            let dst_o = p[2].reshape(&[])?;
+            let src_o = p[3].reshape(&[])?;
+            let src_idx = affine_index(b, &src_o, &dims, &[src_s, 1])?;
+            let values = gather_1d(&p[1], &src_idx)?.reshape(&[n])?;
+            let dst_idx = affine_index(b, &dst_o, &dims, &[dst_s, 1])?.reshape(&[n])?;
+            scatter_1d(&p[0], &dst_idx, &values, ty)
+        })?;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn rope<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        cos: &Self::Storage<T>,
+        sin: &Self::Storage<T>,
+        b: usize,
+        h: usize,
+        t: usize,
+        d: usize,
+        pos: usize,
+        unbatched_rope: bool,
+    ) -> Result<()> {
+        if dst.len != b * h * t * d || src.len != b * h * t * d {
+            crate::bail!("rope unexpected size for src/dst {} {b} {h} {t} {d}", dst.len)
+        }
+        let dev = dst.device.clone();
+        let cs_len = if unbatched_rope { b * t * d / 2 } else { t * d / 2 };
+        let key = [b as i64, h as i64, t as i64, d as i64, unbatched_rope as i64];
+        let inputs =
+            vec![arg(dst), arg(src), arg(cos), arg(sin), Input::Scalar((pos * d / 2) as i64)];
+        dst.value = lazy_op(&dev, "rope", &key, inputs, dst.len, T::DTYPE, move |_b, p| {
+            let (b, h, t, d) = (b as i64, h as i64, t as i64, d as i64);
+            let pos_o = p[4].reshape(&[])?;
+            let x = p[1].reshape(&[b, h, t, d])?;
+            let x1 = x.slice_in_dim(0, d / 2, 1, 3)?;
+            let x2 = x.slice_in_dim(d / 2, d, 1, 3)?;
+            let out_dims = [b, h, t, d / 2];
+            let cs = |cs_p: &XlaOp| -> xla::Result<XlaOp> {
+                let sl = cs_p.dynamic_slice(&[&pos_o], &[cs_len as i64])?;
+                if unbatched_rope {
+                    sl.reshape(&[b, t, d / 2])?.broadcast_in_dim(&out_dims, &[0, 2, 3])
+                } else {
+                    sl.reshape(&[t, d / 2])?.broadcast_in_dim(&out_dims, &[2, 3])
+                }
+            };
+            let cos = cs(&p[2])?;
+            let sin = cs(&p[3])?;
+            let o1 = x1.mul_(&cos)?.sub_(&x2.mul_(&sin)?)?;
+            let o2 = x1.mul_(&sin)?.add_(&x2.mul_(&cos)?)?;
+            let out = o1.concat_in_dim(&[o2], 3)?;
+            out.reshape(&[b * h * t * d])
+        })?;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn rope_i<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        cos: &Self::Storage<T>,
+        sin: &Self::Storage<T>,
+        b: usize,
+        h: usize,
+        t: usize,
+        d: usize,
+        pos: usize,
+        unbatched_rope: bool,
+    ) -> Result<()> {
+        if dst.len != b * h * t * d || src.len != b * h * t * d {
+            crate::bail!("rope-i unexpected size for src/dst {} {b} {h} {t} {d}", dst.len)
+        }
+        let dev = dst.device.clone();
+        let pairs = t * d / 2;
+        let cs_len = if unbatched_rope { b * pairs } else { pairs };
+        let key = [b as i64, h as i64, t as i64, d as i64, unbatched_rope as i64];
+        let inputs =
+            vec![arg(dst), arg(src), arg(cos), arg(sin), Input::Scalar((pos * d / 2) as i64)];
+        dst.value = lazy_op(&dev, "rope_i", &key, inputs, dst.len, T::DTYPE, move |_b, p| {
+            let (b, h) = (b as i64, h as i64);
+            let pairs = pairs as i64;
+            let pos_o = p[4].reshape(&[])?;
+            let x = p[1].reshape(&[b, h, pairs, 2])?;
+            let x1 = x.slice_in_dim(0, 1, 1, 3)?.reshape(&[b, h, pairs])?;
+            let x2 = x.slice_in_dim(1, 2, 1, 3)?.reshape(&[b, h, pairs])?;
+            let out_dims = [b, h, pairs];
+            let cs = |cs_p: &XlaOp| -> xla::Result<XlaOp> {
+                let sl = cs_p.dynamic_slice(&[&pos_o], &[cs_len as i64])?;
+                if unbatched_rope {
+                    sl.reshape(&[b, pairs])?.broadcast_in_dim(&out_dims, &[0, 2])
+                } else {
+                    sl.broadcast_in_dim(&out_dims, &[2])
+                }
+            };
+            let cos = cs(&p[2])?;
+            let sin = cs(&p[3])?;
+            let o1 = x1.mul_(&cos)?.sub_(&x2.mul_(&sin)?)?.reshape(&[b, h, pairs, 1])?;
+            let o2 = x1.mul_(&sin)?.add_(&x2.mul_(&cos)?)?.reshape(&[b, h, pairs, 1])?;
+            let out = o1.concat_in_dim(&[o2], 3)?;
+            out.reshape(&[b * h * pairs * 2])
+        })?;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn gemm<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        (lhs, lhs_o): (&Self::Storage<T>, usize),
+        (rhs, rhs_o): (&Self::Storage<T>, usize),
+        m: usize,
+        n: usize,
+        k: usize,
+        lhs_b: usize,
+        lhs_b_stride: usize,
+        rhs_b_stride: usize,
+        (dst_cs, dst_rs): (usize, usize),
+        (lhs_cs, lhs_rs): (usize, usize),
+        (rhs_cs, rhs_rs): (usize, usize),
+    ) -> Result<()> {
+        // The destination is written contiguously per batch with element
+        // (i, j) at `i * dst_rs + j * dst_cs`, only the row-major and
+        // column-major layouts are supported here.
+        let dst_row_major = (dst_cs == 1 || n == 1) && (dst_rs == n || m == 1);
+        let dst_col_major = dst_cs == m && dst_rs == 1;
+        if !dst_row_major && !dst_col_major {
+            crate::bail!("xla gemm: unsupported dst strides ({dst_cs}, {dst_rs}) for m={m} n={n}")
+        }
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let out_len = lhs_b * m * n;
+        let key = [
+            m as i64,
+            n as i64,
+            k as i64,
+            lhs_b as i64,
+            lhs_b_stride as i64,
+            rhs_b_stride as i64,
+            lhs_cs as i64,
+            lhs_rs as i64,
+            rhs_cs as i64,
+            rhs_rs as i64,
+            dst_row_major as i64,
+        ];
+        let inputs = vec![
+            arg(dst),
+            arg(lhs),
+            arg(rhs),
+            Input::Scalar(lhs_o as i64),
+            Input::Scalar(rhs_o as i64),
+        ];
+        dst.value = lazy_op(&dev, "gemm", &key, inputs, dst_len, T::DTYPE, move |b, p| {
+            let (bs, m, n, k) = (lhs_b as i64, m as i64, n as i64, k as i64);
+            let lhs_o = p[3].reshape(&[])?;
+            let rhs_o = p[4].reshape(&[])?;
+            // Contiguous row-major and transposed operands avoid the index
+            // gather: XLA then lowers the dot to its native gemm kernels.
+            // `d0`/`d1` are the dimensions of the stored (contiguous) matrix.
+            let slice_operand =
+                |p: &XlaOp, off: &XlaOp, d0: i64, d1: i64, b_stride: usize| -> xla::Result<XlaOp> {
+                    let sz = d0 * d1;
+                    if bs == 1 || b_stride as i64 == sz {
+                        p.dynamic_slice(&[off], &[bs * sz])?.reshape(&[bs, d0, d1])
+                    } else {
+                        // b_stride == 0: the same matrix is used for every batch.
+                        let x = p.dynamic_slice(&[off], &[sz])?.reshape(&[d0, d1])?;
+                        x.broadcast_in_dim(&[bs, d0, d1], &[1, 2])
+                    }
+                };
+            // Element (i, j) of the lhs (m x k) lives at `i * lhs_rs + j *
+            // lhs_cs`: (cs, rs) == (1, k) is a stored [m, k] matrix while
+            // (m, 1) is a stored [k, m] matrix; same reasoning for the rhs.
+            let lhs_batch_ok = bs == 1 || lhs_b_stride as i64 == m * k || lhs_b_stride == 0;
+            let rhs_batch_ok = bs == 1 || rhs_b_stride as i64 == k * n || rhs_b_stride == 0;
+            let lhs = if lhs_batch_ok && (lhs_cs == 1 && lhs_rs as i64 == k) {
+                Some((slice_operand(&p[1], &lhs_o, m, k, lhs_b_stride)?, 2i64))
+            } else if lhs_batch_ok && (lhs_cs as i64 == m && lhs_rs == 1) {
+                Some((slice_operand(&p[1], &lhs_o, k, m, lhs_b_stride)?, 1i64))
+            } else {
+                None
+            };
+            let rhs = if rhs_batch_ok && (rhs_cs == 1 && rhs_rs as i64 == n) {
+                Some((slice_operand(&p[2], &rhs_o, k, n, rhs_b_stride)?, 1i64))
+            } else if rhs_batch_ok && (rhs_cs as i64 == k && rhs_rs == 1) {
+                Some((slice_operand(&p[2], &rhs_o, n, k, rhs_b_stride)?, 2i64))
+            } else {
+                None
+            };
+            let res = match (lhs, rhs) {
+                (Some((lhs, lhs_c)), Some((rhs, rhs_c))) => {
+                    lhs.dot_general(&rhs, &[lhs_c], &[rhs_c], &[0], &[0])?
+                }
+                _ => {
+                    // General strided fallback through an index gather.
+                    let lhs_idx =
+                        affine_index(b, &lhs_o, &[bs, m, k], &[lhs_b_stride, lhs_rs, lhs_cs])?;
+                    let rhs_idx =
+                        affine_index(b, &rhs_o, &[bs, k, n], &[rhs_b_stride, rhs_rs, rhs_cs])?;
+                    let lhs = gather_1d(&p[1], &lhs_idx)?;
+                    let rhs = gather_1d(&p[2], &rhs_idx)?;
+                    lhs.dot_general(&rhs, &[2], &[1], &[0], &[0])?
+                }
+            };
+            let res = if dst_row_major { res } else { res.transpose(&[0, 2, 1])? };
+            let res = res.reshape(&[bs * m * n])?;
+            splice(&p[0], dst_len, out_len, res)
+        })?;
+        Ok(())
+    }
+
+    fn index_select<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        ids: &Self::Storage<i64>,
+        num_ids: usize,
+        dim: usize,
+        dims: &[usize],
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let dims_i64: Vec<i64> = dims.iter().map(|&d| d as i64).collect();
+        let mut out_dims = dims_i64.clone();
+        out_dims[dim] = num_ids as i64;
+        let out_len: i64 = out_dims.iter().product();
+        let mut key: Vec<i64> = vec![num_ids as i64, dim as i64];
+        key.extend(dims_i64.iter());
+        let inputs = vec![arg(dst), arg(src), arg(ids)];
+        dst.value = lazy_op(&dev, "index_select", &key, inputs, dst_len, T::DTYPE, move |b, p| {
+            let src_n: i64 = dims_i64.iter().product();
+            let src = p[1].slice_in_dim(0, src_n, 1, 0)?.reshape(&dims_i64)?;
+            let ids = p[2].slice_in_dim(0, num_ids as i64, 1, 0)?;
+            // An index of -1 selects zeros rather than a row of the source.
+            let zero = b.c0(0i64)?;
+            let clamped = ids.max(&zero)?;
+            let sel = src.take(&clamped, dim as i64)?;
+            let mask = ids.ge(&zero)?.broadcast_in_dim(&out_dims, &[dim as i64])?;
+            let zeros = sel.zeros_like()?;
+            let v = mask.select(&sel, &zeros)?.reshape(&[out_len])?;
+            splice(&p[0], dst_len, out_len as usize, v)
+        })?;
+        Ok(())
+    }
+
+    fn apply_causality_mask<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        bh: usize,
+        t1: usize,
+        t2: usize,
+        offset: usize,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let n = bh * t1 * t2;
+        let key = [bh as i64, t1 as i64, t2 as i64];
+        let inputs = vec![arg(dst), Input::Scalar(offset as i64)];
+        dst.value =
+            lazy_op(&dev, "causality_mask", &key, inputs, dst_len, T::DTYPE, move |b, p| {
+                let (bh, t1, t2) = (bh as i64, t1 as i64, t2 as i64);
+                let x = p[0].slice_in_dim(0, n as i64, 1, 0)?.reshape(&[bh, t1, t2])?;
+                let offset = p[1].reshape(&[])?;
+                let i1 = b.iota(ElementType::S64, &[t1, t2], 0)?;
+                let i2 = b.iota(ElementType::S64, &[t1, t2], 1)?;
+                let mask = i2.gt(&i1.add_(&offset)?)?.broadcast_in_dim(&[bh, t1, t2], &[1, 2])?;
+                let neg_inf =
+                    from_f32(&b.c0(f32::NEG_INFINITY)?, T::DTYPE)?.broadcast(&[bh, t1, t2])?;
+                let v = mask.select(&neg_inf, &x)?.reshape(&[bh * t1 * t2])?;
+                splice(&p[0], dst_len, n, v)
+            })?;
+        Ok(())
+    }
+
+    fn softmax<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        dim_m1: usize,
+        d: usize,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let n = d * dim_m1;
+        let key = [dim_m1 as i64, d as i64];
+        let inputs = vec![arg(dst), arg(src)];
+        dst.value = lazy_op(&dev, "softmax", &key, inputs, dst_len, T::DTYPE, move |_b, p| {
+            let (d, dim_m1) = (d as i64, dim_m1 as i64);
+            let x = p[1].slice_in_dim(0, n as i64, 1, 0)?.reshape(&[d, dim_m1])?;
+            let x = to_f32(&x)?;
+            let max = x.reduce_max(&[1], true)?;
+            let e = x.sub_(&max)?.exp()?;
+            let s = e.reduce_sum(&[1], true)?;
+            let v = from_f32(&e.div_(&s)?, T::DTYPE)?.reshape(&[n as i64])?;
+            splice(&p[0], dst_len, n, v)
+        })?;
+        Ok(())
+    }
+
+    fn rms_norm<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        alpha: &Self::Storage<T>,
+        dim_m1: usize,
+        d: usize,
+        eps: f32,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let n = d * dim_m1;
+        let key = [dim_m1 as i64, d as i64, eps.to_bits() as i64];
+        let inputs = vec![arg(dst), arg(src), arg(alpha)];
+        dst.value = lazy_op(&dev, "rms_norm", &key, inputs, dst_len, T::DTYPE, move |b, p| {
+            let (d, dim_m1) = (d as i64, dim_m1 as i64);
+            let x = p[1].slice_in_dim(0, n as i64, 1, 0)?.reshape(&[d, dim_m1])?;
+            let x = to_f32(&x)?;
+            let alpha = to_f32(&p[2].slice_in_dim(0, dim_m1, 1, 0)?)?;
+            let sum2 = x.mul_(&x)?.reduce_sum(&[1], true)?;
+            let m = sum2.div_(&b.c0(dim_m1 as f32)?)?.add_(&b.c0(eps)?)?.rsqrt()?;
+            let alpha = alpha.broadcast_in_dim(&[d, dim_m1], &[1])?;
+            let v = x.mul_(&m)?.mul_(&alpha)?;
+            let v = from_f32(&v, T::DTYPE)?.reshape(&[n as i64])?;
+            splice(&p[0], dst_len, n, v)
+        })?;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn layer_norm<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        weight: &Self::Storage<T>,
+        bias: &Self::Storage<T>,
+        dim_m1: usize,
+        d: usize,
+        eps: f32,
+        remove_mean: bool,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let n = d * dim_m1;
+        let key = [dim_m1 as i64, d as i64, eps.to_bits() as i64, remove_mean as i64];
+        let inputs = vec![arg(dst), arg(src), arg(weight), arg(bias)];
+        dst.value = lazy_op(&dev, "layer_norm", &key, inputs, dst_len, T::DTYPE, move |b, p| {
+            let (d, dim_m1) = (d as i64, dim_m1 as i64);
+            let x = p[1].slice_in_dim(0, n as i64, 1, 0)?.reshape(&[d, dim_m1])?;
+            let x = to_f32(&x)?;
+            let weight = to_f32(&p[2].slice_in_dim(0, dim_m1, 1, 0)?)?
+                .broadcast_in_dim(&[d, dim_m1], &[1])?;
+            let bias = to_f32(&p[3].slice_in_dim(0, dim_m1, 1, 0)?)?
+                .broadcast_in_dim(&[d, dim_m1], &[1])?;
+            let dim_f = b.c0(dim_m1 as f32)?;
+            let mean = x.reduce_sum(&[1], true)?.div_(&dim_f)?;
+            let centered = x.sub_(&mean)?;
+            let var = centered.mul_(&centered)?.reduce_sum(&[1], true)?.div_(&dim_f)?;
+            let inv_std = var.add_(&b.c0(eps)?)?.rsqrt()?;
+            let normalized = if remove_mean { centered.clone() } else { x.clone() };
+            let v = normalized.mul_(&inv_std)?.mul_(&weight)?.add_(&bias)?;
+            let v = from_f32(&v, T::DTYPE)?.reshape(&[n as i64])?;
+            splice(&p[0], dst_len, n, v)
+        })?;
+        Ok(())
+    }
+
+    fn reduce_max<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        dim_size: usize,
+        outer_size: usize,
+        inner_size: usize,
+    ) -> Result<()> {
+        reduce_impl::<T>(dst, src, dim_size, outer_size, inner_size, Reduce::Max)
+    }
+
+    fn reduce_min<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        dim_size: usize,
+        outer_size: usize,
+        inner_size: usize,
+    ) -> Result<()> {
+        reduce_impl::<T>(dst, src, dim_size, outer_size, inner_size, Reduce::Min)
+    }
+
+    fn reduce_sum<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        dim_size: usize,
+        outer_size: usize,
+        inner_size: usize,
+    ) -> Result<()> {
+        reduce_impl::<T>(dst, src, dim_size, outer_size, inner_size, Reduce::Sum)
+    }
+
+    fn reduce_argmax<T: WithDTypeF>(
+        dst: &mut Self::Storage<i64>,
+        src: &Self::Storage<T>,
+        dim_size: usize,
+        outer_size: usize,
+        inner_size: usize,
+    ) -> Result<()> {
+        reduce_arg_impl::<T>(dst, src, dim_size, outer_size, inner_size, false)
+    }
+
+    fn reduce_argmin<T: WithDTypeF>(
+        dst: &mut Self::Storage<i64>,
+        src: &Self::Storage<T>,
+        dim_size: usize,
+        outer_size: usize,
+        inner_size: usize,
+    ) -> Result<()> {
+        reduce_arg_impl::<T>(dst, src, dim_size, outer_size, inner_size, true)
+    }
+
+    fn copy_strided<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        src_offset: usize,
+        dims: &[usize],
+        src_strides: &[usize],
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let n = product(dims);
+        let dims_i64: Vec<i64> = dims.iter().map(|&d| d as i64).collect();
+        let strides = src_strides.to_vec();
+        let mut key: Vec<i64> = dims_i64.clone();
+        key.extend(strides.iter().map(|&s| s as i64));
+        let inputs = vec![arg(dst), arg(src), Input::Scalar(src_offset as i64)];
+        dst.value = lazy_op(&dev, "copy_strided", &key, inputs, dst_len, T::DTYPE, move |b, p| {
+            let src_o = p[2].reshape(&[])?;
+            let idx = affine_index(b, &src_o, &dims_i64, &strides)?;
+            let v = gather_1d(&p[1], &idx)?.reshape(&[n as i64])?;
+            splice(&p[0], dst_len, n, v)
+        })?;
+        Ok(())
+    }
+
+    fn scatter_set<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        ids: &Self::Storage<i64>,
+        dim: usize,
+        dst_dims: &[usize],
+        src_dims: &[usize],
+    ) -> Result<()> {
+        let left: usize = src_dims[..dim].iter().product();
+        let right: usize = src_dims[dim + 1..].iter().product();
+        let src_dim = src_dims[dim];
+        let dst_dim = dst_dims[dim];
+        let n = left * src_dim * right;
+        let dev = dst.device.clone();
+        let ty = ety(T::DTYPE);
+        let key = [left as i64, src_dim as i64, right as i64, dst_dim as i64];
+        let inputs = vec![arg(dst), arg(src), arg(ids)];
+        dst.value = lazy_op(&dev, "scatter_set", &key, inputs, dst.len, T::DTYPE, move |b, p| {
+            let dims = [left as i64, src_dim as i64, right as i64];
+            // Flat destination index for source element (l, i, r):
+            // l * dst_dim * right + ids[l, i, r] * right + r.
+            let zero = b.c0(0i64)?;
+            let base = affine_index(b, &zero, &dims, &[dst_dim * right, 0, 1])?;
+            let ids = p[2].slice_in_dim(0, n as i64, 1, 0)?.reshape(&dims)?;
+            let idx = base.add_(&ids.mul_(&b.c0(right as i64)?)?)?.reshape(&[n as i64])?;
+            let updates = p[1].slice_in_dim(0, n as i64, 1, 0)?;
+            scatter_1d(&p[0], &idx, &updates, ty)
+        })?;
+        Ok(())
+    }
+
+    fn broadcast_binary<T: WithDType>(
+        dst: &mut Self::Storage<T>,
+        lhs: &Self::Storage<T>,
+        rhs: &Self::Storage<T>,
+        dst_shape: &[usize],
+        lhs_strides: &[usize],
+        rhs_strides: &[usize],
+        op: BinaryOp,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let n = product(dst_shape);
+        let dims_i64: Vec<i64> = dst_shape.iter().map(|&d| d as i64).collect();
+        let lhs_strides = lhs_strides.to_vec();
+        let rhs_strides = rhs_strides.to_vec();
+        let mut key: Vec<i64> = vec![binary_key(op)];
+        key.extend(dims_i64.iter());
+        key.extend(lhs_strides.iter().map(|&s| s as i64));
+        key.extend(rhs_strides.iter().map(|&s| s as i64));
+        let inputs = vec![arg(dst), arg(lhs), arg(rhs)];
+        dst.value =
+            lazy_op(&dev, "broadcast_binary", &key, inputs, dst_len, T::DTYPE, move |b, p| {
+                let zero = b.c0(0i64)?;
+                let lhs_idx = affine_index(b, &zero, &dims_i64, &lhs_strides)?;
+                let rhs_idx = affine_index(b, &zero, &dims_i64, &rhs_strides)?;
+                let lhs = gather_1d(&p[1], &lhs_idx)?;
+                let rhs = gather_1d(&p[2], &rhs_idx)?;
+                let v = build_binary(&lhs, &rhs, op)?.reshape(&[n as i64])?;
+                splice(&p[0], dst_len, n, v)
+            })?;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn conv1d<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let n = batch * out_channels * out_length;
+        let key = [
+            batch as i64,
+            in_channels as i64,
+            out_channels as i64,
+            length as i64,
+            kernel_size as i64,
+            stride as i64,
+            padding as i64,
+            dilation as i64,
+            groups as i64,
+        ];
+        let inputs = vec![arg(dst), arg(src), arg(kernel)];
+        dst.value = lazy_op(&dev, "conv1d", &key, inputs, dst_len, T::DTYPE, move |_b, p| {
+            let src_n = (batch * in_channels * length) as i64;
+            let src = p[1].slice_in_dim(0, src_n, 1, 0)?.reshape(&[
+                batch as i64,
+                in_channels as i64,
+                length as i64,
+            ])?;
+            let kernel_n = (out_channels * (in_channels / groups) * kernel_size) as i64;
+            let kernel = p[2].slice_in_dim(0, kernel_n, 1, 0)?.reshape(&[
+                out_channels as i64,
+                (in_channels / groups) as i64,
+                kernel_size as i64,
+            ])?;
+            let v =
+                src.conv1d(&kernel, stride as i64, padding as i64, dilation as i64, groups as i64)?;
+            let v = v.reshape(&[n as i64])?;
+            splice(&p[0], dst_len, n, v)
+        })?;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn conv_transpose1d<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        output_padding: usize,
+        groups: usize,
+    ) -> Result<()> {
+        let dev = dst.device.clone();
+        let dst_len = dst.len;
+        let n = batch * out_channels * out_length;
+        let key = [
+            batch as i64,
+            in_channels as i64,
+            out_channels as i64,
+            length as i64,
+            kernel_size as i64,
+            stride as i64,
+            padding as i64,
+            output_padding as i64,
+            groups as i64,
+        ];
+        let inputs = vec![arg(dst), arg(src), arg(kernel)];
+        dst.value =
+            lazy_op(&dev, "conv_transpose1d", &key, inputs, dst_len, T::DTYPE, move |_b, p| {
+                let src_n = (batch * in_channels * length) as i64;
+                let src = p[1].slice_in_dim(0, src_n, 1, 0)?.reshape(&[
+                    batch as i64,
+                    in_channels as i64,
+                    length as i64,
+                ])?;
+                let kernel_n = (in_channels * (out_channels / groups) * kernel_size) as i64;
+                let kernel = p[2].slice_in_dim(0, kernel_n, 1, 0)?.reshape(&[
+                    in_channels as i64,
+                    (out_channels / groups) as i64,
+                    kernel_size as i64,
+                ])?;
+                let v = src.conv_transpose1d(
+                    &kernel,
+                    stride as i64,
+                    padding as i64,
+                    output_padding as i64,
+                    /* dilation= */ 1,
+                    groups as i64,
+                )?;
+                let v = v.reshape(&[n as i64])?;
+                splice(&p[0], dst_len, n, v)
+            })?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Reduce {
+    Max,
+    Min,
+    Sum,
+}
+
+fn reduce_impl<T: WithDTypeF>(
+    dst: &mut Storage<T>,
+    src: &Storage<T>,
+    dim_size: usize,
+    outer_size: usize,
+    inner_size: usize,
+    red: Reduce,
+) -> Result<()> {
+    let dev = dst.device.clone();
+    let dst_len = dst.len;
+    let n_in = outer_size * dim_size * inner_size;
+    let n_out = outer_size * inner_size;
+    let (name, red_key) = match red {
+        Reduce::Max => ("reduce_max", 0i64),
+        Reduce::Min => ("reduce_min", 1),
+        Reduce::Sum => ("reduce_sum", 2),
+    };
+    let key = [dim_size as i64, outer_size as i64, inner_size as i64, red_key];
+    let inputs = vec![arg(dst), arg(src)];
+    dst.value = lazy_op(&dev, name, &key, inputs, dst_len, T::DTYPE, move |_b, p| {
+        let dims = [outer_size as i64, dim_size as i64, inner_size as i64];
+        let x = p[1].slice_in_dim(0, n_in as i64, 1, 0)?.reshape(&dims)?;
+        let v = match red {
+            Reduce::Max => x.reduce_max(&[1], false)?,
+            Reduce::Min => x.reduce_min(&[1], false)?,
+            Reduce::Sum => x.reduce_sum(&[1], false)?,
+        };
+        let v = v.reshape(&[n_out as i64])?;
+        splice(&p[0], dst_len, n_out, v)
+    })?;
+    Ok(())
+}
+
+fn reduce_arg_impl<T: WithDTypeF>(
+    dst: &mut Storage<i64>,
+    src: &Storage<T>,
+    dim_size: usize,
+    outer_size: usize,
+    inner_size: usize,
+    is_min: bool,
+) -> Result<()> {
+    let dev = dst.device.clone();
+    let dst_len = dst.len;
+    let n_in = outer_size * dim_size * inner_size;
+    let n_out = outer_size * inner_size;
+    let name = if is_min { "reduce_argmin" } else { "reduce_argmax" };
+    let key = [dim_size as i64, outer_size as i64, inner_size as i64, dtype_key(T::DTYPE)];
+    let inputs = vec![arg(dst), arg(src)];
+    dst.value = lazy_op(&dev, name, &key, inputs, dst_len, DType::I64, move |_b, p| {
+        let dims = [outer_size as i64, dim_size as i64, inner_size as i64];
+        let x = p[1].slice_in_dim(0, n_in as i64, 1, 0)?.reshape(&dims)?;
+        let v =
+            if is_min { x.argmin(ElementType::S64, 1)? } else { x.argmax(ElementType::S64, 1)? };
+        let v = v.reshape(&[n_out as i64])?;
+        splice(&p[0], dst_len, n_out, v)
+    })?;
+    Ok(())
+}

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -36,6 +36,12 @@ macro_rules! test_all_backends {
             fn [<$test_name _webgpu>]() -> Result<()> {
                 $test_fn(&webgpu_device())
             }
+
+            #[cfg(feature = "xla")]
+            #[test]
+            fn [<$test_name _xla>]() -> Result<()> {
+                $test_fn(&xla_device())
+            }
         }
     };
 }
@@ -50,6 +56,16 @@ fn webgpu_device() -> xn::webgpu_backend::Device {
     use std::sync::OnceLock;
     static DEVICE: OnceLock<xn::webgpu_backend::Device> = OnceLock::new();
     DEVICE.get_or_init(|| xn::webgpu_backend::Device::new(0).expect("init webgpu device")).clone()
+}
+
+/// A single XLA device (PJRT client) shared across the whole test binary:
+/// creating a client is expensive and sharing it lets all tests reuse the
+/// executable cache.
+#[cfg(feature = "xla")]
+fn xla_device() -> xn::xla_backend::Device {
+    use std::sync::OnceLock;
+    static DEVICE: OnceLock<xn::xla_backend::Device> = OnceLock::new();
+    DEVICE.get_or_init(|| xn::xla_backend::Device::new(0).expect("init xla device")).clone()
 }
 
 // =============================================================================


### PR DESCRIPTION
Draft: an XLA/PJRT backend for xn, so the same models can run on the CPU, GPU, and TPU PJRT platforms without hand-written kernels per target. The interesting question was whether a compiler-oriented runtime can be driven from an eager framework at all; the short answer is yes, for static-shape workloads it lands within 10% of the hand-written CUDA backend, and the remaining gaps are understood.

Required LaurentMazare/xla-rs#24 (PJRT handles need `Send`/`Sync`, plus a byte-level literal download for f16/bf16), now merged. The `xla` dependency tracks xla-rs `main`; the lockfile pins the merge commit. Worth repointing at a crates.io release once one includes those changes.

## Why this is not obviously possible

`Backend` is imperative: ~35 methods that each write into a pre-allocated `&mut Storage<T>`. XLA is the opposite — build a computation, compile it, execute. Compiling per eager op is unusable.

Two things made it work. Every method already takes `dst` as an output parameter, so a backend can treat "mutation" as rebinding what the storage points at, which is exactly functional form. And the trait speaks in post-layout terms (stride arrays with zeros for broadcasts, raw strides for `copy_strided`/`copy2d`) rather than logical ops, which sounds like the hard part but reduces to one affine-index + gather helper, with `dynamic_slice`-based fast paths where the layout is contiguous.

## Design

**Storage is a rank-1 PJRT buffer, and operations are lazy.** Each `Backend` method records a `LazyNode` holding its shape parameters and a closure that builds its XLA subgraph. Nodes form a DAG; the graph flushes when data is read on the host or `synchronize` is called. Only nodes still referenced from outside the flushed graph become outputs, so intermediates fuse away.

**Hybrid compile policy.** Flushing hashes the graph structure. First occurrence of a structure runs node by node against a per-op executable cache; on repeat, the whole graph compiles into one fused executable that is cached and replayed. This matters because it makes the two regimes independent: steady-state loops get one XLA program per step, while shape-churning code falls back to per-op executables and never pays for whole-graph compiles it can't reuse. `XN_XLA_FUSE=always|never` overrides for debugging.

**Runtime scalars stay out of the graph key.** Offsets, rope positions, causality offsets, and fill/scale values are `Input::Scalar`, packed into a single S64 side buffer per flush. A decode loop at position 5 and position 300 produces the same graph key, so the cache stays hot.

**gemm has gather-free fast paths.** Row-major and transposed operands use `dynamic_slice` + `dot_general` contracting-dim selection instead of an index gather, which is what lets XLA lower to cuBLAS. This alone took matmul from 754 µs to 144 µs. The general strided gather remains as a fallback.

**`KvCache::fixed` in the llama model** (`models/llama.rs`) preallocates `[b, kv_heads, cap, head_dim]` and writes new keys/values in place with `slice_set`, attending over the full capacity. No new masking was needed: the existing causality mask already hides positions beyond `pos`, and the cache is zero-initialised so masked slots can't produce NaNs. The growing `Tensor::cat` cache remains the default; pass a fixed cache from the first `forward` to opt in.

## Results

RTX 4080 SUPER, CUDA 13.2, `xla_extension` 0.10-cuda13, via the new `examples/backend_bench.rs`. "eager" is this backend before lazy capture, included to show where the wins came from.

| Workload | native CUDA | XLA eager | XLA lazy |
|---|---|---|---|
| matmul 32×2048 · 2048×11264, f32 | 156 µs | 829 µs | **144 µs** |
| matmul, bf16 | 38 µs | 442 µs | **43 µs** |
| SmolLM-135M prefill-128, f32 | 5.2 ms | 39.4 ms | **6.1 ms** |
| SmolLM-135M prefill-128, bf16 | 3.3 ms | 40.3 ms | **5.5 ms** |
| Mimi streaming encode, f32 | 1.30 ms/chunk | 388 ms/chunk | **1.44 ms/chunk** |
| SmolLM-135M decode, f32 | 2.7 ms/tok | 274 ms/tok | **4.9 ms/tok** |
| SmolLM-135M decode, bf16 | 2.3 ms/tok | — | **4.0 ms/tok** |

Decode figures use the fixed KV cache on both backends and report median per-step latency; Mimi is steady state after the 250-frame context fills (chunks are 1920 samples = 80 ms of audio, so 1.44 ms/chunk is ~56× realtime). Greedy token output is bit-identical across cuda-growing-cache, cuda-fixed-cache, and xla-fixed-cache.

Three observations worth recording:

**Eager XLA on GPU is not viable, and the reason is dispatch, not compute.** Each op was a synchronous PJRT round-trip; prefill runs ~600 ops in 39 ms, i.e. a ~65 µs/op floor. bf16 barely helped (dispatch-bound) while native got its full 5× from cuBLAS. This is why lazy capture — not kernel tuning — was the right lever.

**Shape stability dominates everything else.** Mimi went 388 ms → 1.44 ms/chunk purely from graph reuse. Llama decode with the growing cat-based cache stays at ~314 ms/step *even with lazy capture*, because every step is a new shape; the same code with a fixed cache runs at 4.9 ms. On a compiler backend, cache growth strategy is a performance decision, not an implementation detail.

**The fixed cache is a small win for CUDA too** — 365 vs 335 tok/s f32 — since it drops the per-step concatenation.

## Cost model

- **First compile**: a fused whole-step graph costs ~5 s for SmolLM-135M decode (visible as the max in the first steps) and is paid once per distinct structure. Fine for a server, noticeable for a CLI; `compile_with_autotune_cache` is already exposed by xla-rs and would help.
- **Fixed-cache capacity sizes attention compute**, so pick the smallest capacity that fits the generation length.
- **Lazy semantics**: results that are never read are never computed. Benchmarks must synchronize per iteration or they measure nothing (the first version of `backend_bench` reported 6000 TFLOP/s before this was fixed).

## Known limitations

- `gemm` supports row-major and column-major destination strides and bails otherwise; no current code path hits that.
- `scatter_set` with duplicate indices is nondeterministic, where CPU is last-write-wins.
- RNG runs on the host: XLA's rng op inside a cached executable would replay identical values every execution.
- Quantized dtypes are not supported; the backend is `WithDType` only.

## Next steps, in the order I'd do them

1. **Buffer donation** (`setup_alias`, already in xla-rs) for the KV caches. They are currently inputs *and* outputs of the fused program, so PJRT copies ~12 MB per decode step. This is the bulk of the remaining 1.8× decode gap.
2. **Async execution.** `execute_b` is synchronous; overlapping host and device work would help prefill.
3. **Persistent executable cache** on disk, to amortise the first-compile cost across processes.
4. **TPU validation.** The backend is platform-agnostic by construction but has only been exercised on CPU and CUDA.

## Testing

All 208 tensor tests run against the new backend (`--features xla`, shared PJRT device) and pass under all three fusion policies. Default builds are unaffected — the feature is off, and `cargo check -p xn` is clean.

Reproduce with `XLA_EXTENSION_DIR=... cargo run --release --features cuda,xla --example backend_bench -- --bench llama-decode --backend xla --dtype bf16 --tokens 200 --kv-cap 256`. GPU runs need cudnn9/nccl/nvshmem/nvrtc on `LD_LIBRARY_PATH` alongside the CUDA `xla_extension` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LELgDadzc42WwgvdoZLLc8
