### PR TITLE
Fall back to a dequantized matmul for unaligned fp8 linear shapes

### DIFF
--- a/xn-core/src/cuda_backend/cublaslt.rs
+++ b/xn-core/src/cuda_backend/cublaslt.rs
@@ -312,7 +312,14 @@ impl CudaBlasLT {
                 c_layout.handle,
                 c_layout.handle,
                 matmul_pref.handle,
-            )?
+            )
+            .map_err(|e| {
+                crate::Error::msg(format!(
+                    "cublasLt fp8 heuristic failed: {e:?} \
+                     (m={m} n={n} k={k} outer_vec={use_outer_vec} batch={:?})",
+                    batch.map(|b| b.count)
+                ))
+            })?
         };
 
         // Launch matmul.

--- a/xn-core/src/cuda_backend/quantization.rs
+++ b/xn-core/src/cuda_backend/quantization.rs
@@ -373,8 +373,8 @@ impl Fp8Linear {
         // Flatten batch dims into M for 2D matmul.
         let xs = xs.reshape(((), k))?;
         let (m, _) = xs.dims2()?;
-        let wdims = self.weight.shape.dims();
-        let (n, wk) = (wdims[0], wdims[1]);
+        let n = self.weight.shape.dim(0)?;
+        let wk = self.weight.shape.dim(1)?;
         // cublasLt fp8 matmuls need 16-aligned dims; unaligned shapes (the
         // [text_card + 1, d] prefix-table fold at load, tiny head
         // projections) fall back to a dequantized bf16 matmul.

--- a/xn-core/src/cuda_backend/quantization.rs
+++ b/xn-core/src/cuda_backend/quantization.rs
@@ -372,11 +372,22 @@ impl Fp8Linear {
         let batch_dims = &dims[..rank - 1];
         // Flatten batch dims into M for 2D matmul.
         let xs = xs.reshape(((), k))?;
-        let xs_fp8 = match self.weight.scale_mode {
-            Fp8ScaleMode::PerTensor => Fp8Tensor::quantize(&xs)?,
-            Fp8ScaleMode::PerToken => Fp8Tensor::quantize_per_token(&xs)?,
+        let (m, _) = xs.dims2()?;
+        let wdims = self.weight.shape.dims();
+        let (n, wk) = (wdims[0], wdims[1]);
+        // cublasLt fp8 matmuls need 16-aligned dims; unaligned shapes (the
+        // [text_card + 1, d] prefix-table fold at load, tiny head
+        // projections) fall back to a dequantized bf16 matmul.
+        let out = if m % 16 != 0 || n % 16 != 0 || wk % 16 != 0 {
+            let w: Tensor<bf16, Device> = self.weight.dequantize()?;
+            xs.matmul_t(&w)?
+        } else {
+            let xs_fp8 = match self.weight.scale_mode {
+                Fp8ScaleMode::PerTensor => Fp8Tensor::quantize(&xs)?,
+                Fp8ScaleMode::PerToken => Fp8Tensor::quantize_per_token(&xs)?,
+            };
+            xs_fp8.matmul_t(&self.weight)?
         };
-        let out = xs_fp8.matmul_t(&self.weight)?;
 
         // Restore batch dims: [...batch, N].
         let (_m, n) = out.dims2()?;


### PR DESCRIPTION
cuBLASLt fp8 matmuls require 16-aligned dimensions, and `Fp8Linear::forward` fed it whatever shape the model had. Two real shapes break it: the `[text_card + 1, d_model]` prefix-table fold (m = 20001) that gradium-serve's xn worker runs at load since its prefix-prefill change landed, and a small `[4, d]` head projection. Both fail the heuristic with `CUBLAS_STATUS_NOT_SUPPORTED`, so `XN_DTYPE=fp8` / `fp8-per-token` currently abort at model load — on any GPU.

Unaligned shapes now dequantize the weight to bf16 and take the plain matmul; aligned shapes (all the per-step decode matmuls — fb and fb×prefix flatten to multiples of 16) keep the fp8 path. The heuristic error now includes `(m, n, k, scale mode, batch)`, which is what pinned this down.

Verified: the 6 fp8 cuda tests pass on sm_89, and the gradium TTS worker boots and serves with `XN_DTYPE=fp8` on sm_89 (RTX 4080S) and sm_120 (RTX PRO 6000) — both previously aborted at load. Full sweep numbers on sm_120 (fp8 arm): https://claude.ai/code/artifact/039cab55-7922-484b-9a30-32c60fccf62d

Two things established along the way, no action in this PR:
- Per-token (`OUTER_VEC_32F`) remains rejected by the heuristic on sm_89 and sm_120 at fully aligned shapes — consistent with the existing test guard (`test_fp8_matmul_t_per_token` skips below CC 9.0) and with NVIDIA documenting outer-vector scaling for Hopper.
- `CUBLASLT_MATMUL_DESC_FAST_ACCUM` is *not* needed for the per-tensor path on either consumer part (tested with and without); an earlier hypothesis blaming it was wrong, so it is deliberately not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017phHCJvH9dxZFyV2Wv91BL