### PR TITLE
Route f32 conv gemms through cublasGemmEx with a tf32-by-default toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,7 +3605,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xn"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "ash",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "xn-moshi"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["xn-flash-attn"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 description = "Another minimalist deep-learning framework optimized for inference."
 repository = "https://github.com/LaurentMazare/xn"
 keywords = ["pytorch", "deep-learning", "machine-learning"]

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -665,6 +665,22 @@ static MM_BF16_REDUCED_PRECISION: std::sync::atomic::AtomicBool =
 static MM_F32_REDUCED_PRECISION: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+static CONV_F32_REDUCED_PRECISION: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(true);
+
+/// Whether f32 convolutions may use tf32 tensor cores. Defaults to true,
+/// matching PyTorch: convolutions tolerate the tf32 mantissa well and it is
+/// what cuDNN-based stacks (including torch itself) run by default, while
+/// f32 matmuls stay full precision unless
+/// [`set_gemm_reduced_precision_f32`] is called.
+pub fn conv_reduced_precision_f32() -> bool {
+    CONV_F32_REDUCED_PRECISION.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+pub fn set_conv_reduced_precision_f32(b: bool) {
+    CONV_F32_REDUCED_PRECISION.store(b, std::sync::atomic::Ordering::Relaxed)
+}
+
 pub fn gemm_reduced_precision_f32() -> bool {
     MM_F32_REDUCED_PRECISION.load(std::sync::atomic::Ordering::Relaxed)
 }
@@ -2083,6 +2099,53 @@ fn conv1d_gemm<T: WithDTypeF>(
     }
 }
 
+/// f32 gemm for the convolution paths, through `cublasGemmEx` so the compute
+/// type can honor [`conv_reduced_precision_f32`] (the plain `cublasSgemm`
+/// wrapper has no compute-type parameter).
+unsafe fn conv_gemm_ex_f32(
+    device: &Device,
+    cfg: cudarc::cublas::GemmConfig<f32>,
+    a: &CudaSlice<f32>,
+    b: &CudaSlice<f32>,
+    c: &mut CudaSlice<f32>,
+) -> std::result::Result<(), cudarc::cublas::result::CublasError> {
+    use cudarc::cublas::sys;
+    use cudarc::driver::{DevicePtr, DevicePtrMut};
+
+    let compute_type = if conv_reduced_precision_f32() {
+        sys::cublasComputeType_t::CUBLAS_COMPUTE_32F_FAST_TF32
+    } else {
+        sys::cublasComputeType_t::CUBLAS_COMPUTE_32F
+    };
+    let stream = device.stream.clone();
+    let (a, _guard_a) = a.device_ptr(&stream);
+    let (b, _guard_b) = b.device_ptr(&stream);
+    let (c, _guard_c) = c.device_ptr_mut(&stream);
+    unsafe {
+        cudarc::cublas::result::gemm_ex(
+            *device.blas.handle(),
+            cfg.transa,
+            cfg.transb,
+            cfg.m,
+            cfg.n,
+            cfg.k,
+            &cfg.alpha as *const f32 as *const _,
+            a as *const _,
+            sys::cudaDataType_t::CUDA_R_32F,
+            cfg.lda,
+            b as *const _,
+            sys::cudaDataType_t::CUDA_R_32F,
+            cfg.ldb,
+            &cfg.beta as *const f32 as *const _,
+            c as *mut _,
+            sys::cudaDataType_t::CUDA_R_32F,
+            cfg.ldc,
+            compute_type,
+            sys::cublasGemmAlgo_t::CUBLAS_GEMM_DEFAULT,
+        )
+    }
+}
+
 fn conv1d_gemm_f32(
     device: &Device,
     col: &CudaSlice<f32>,
@@ -2124,7 +2187,7 @@ fn conv1d_gemm_f32(
         transb: cublasOperation_t::CUBLAS_OP_N,
     };
     unsafe {
-        device.blas.gemm(gemm, kernel, col, result)?;
+        conv_gemm_ex_f32(device, gemm, kernel, col, result)?;
     }
     Ok(())
 }
@@ -2406,7 +2469,7 @@ fn conv_transpose1d_gemm_f32(
         transb: cublasOperation_t::CUBLAS_OP_N,
     };
     unsafe {
-        device.blas.gemm(gemm, kernel, src, result)?;
+        conv_gemm_ex_f32(device, gemm, kernel, src, result)?;
     }
     Ok(())
 }


### PR DESCRIPTION
`conv1d` (im2col) and `conv_transpose1d` run their f32 gemms through the plain `cublasSgemm` wrapper, which has no compute-type parameter — so they always execute in full f32, and `set_gemm_reduced_precision_f32` silently does not apply to them (its only consumer is the strided-batched matmul path). On the mimi 48 kHz decoder this is ~90% of the f32 gemm time.

This PR gives convolutions their own precision toggle with **PyTorch's split semantics**:

- `conv_reduced_precision_f32()` / `set_conv_reduced_precision_f32()` — **defaults to `true` (tf32)**, like `torch.backends.cudnn.allow_tf32`
- the existing gemm flag and its `false` (full f32) default are untouched, like `torch.backends.cuda.matmul.allow_tf32`

Both f32 conv gemm sites now go through `cublasGemmEx` with `CUBLAS_COMPUTE_32F_FAST_TF32` / `CUBLAS_COMPUTE_32F` selected by the flag. Grouped convs use a custom direct kernel (no cublas) and are unaffected; f16/bf16 conv gemms unchanged.

**Note this changes default numerics** for f32 convs (10-bit mantissa in the gemm inputs). Context for why the default is defensible: PyTorch has shipped tf32 cudnn convs by default since 1.7 — so the gradium py-inference reference decodes mimi audio through tf32 convs today — and XLA (worker-xla) likewise runs f32 convs as tf32 `xmma` kernels by default. xn was the outlier at full f32. `set_conv_reduced_precision_f32(false)` restores the old behavior.

Measured (RTX 4080S, mimi 48 kHz decode step, gr4d/warp-tts-af440bf5.1):

| batch | before | after | conv gemm kernels |
|---|---|---|---|
| 16 | 15.6 ms | 14.6 ms | `ampere_sgemm_*` → `s1688gemm_*` |
| 32 | 30.2 ms | **28.0 ms** | gemm kernel time −24% |

Matmul-path kernels verified still `ampere_sgemm` (nsys), i.e. the split behaves exactly as intended. All 208+ cuda tests pass under the new default with existing tolerances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017phHCJvH9dxZFyV2Wv91BL