### PR TITLE
Fuse the snake activation and the conv bias epilogue (mimi decode −28% at b32)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,7 +3605,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xn"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "ash",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "xn-moshi"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["xn-flash-attn"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 description = "Another minimalist deep-learning framework optimized for inference."
 repository = "https://github.com/LaurentMazare/xn"
 keywords = ["pytorch", "deep-learning", "machine-learning"]

--- a/xn-core/cuda-kernels/broadcast.cu
+++ b/xn-core/cuda-kernels/broadcast.cu
@@ -369,3 +369,49 @@ BROADCAST_ALL_OPS(__half, f16)
 BROADCAST_ALL_OPS(float, f32)
 BROADCAST_ALL_OPS(int64_t, i64)
 BROADCAST_ALL_OPS(uint8_t, u8)
+
+// ============================================================================
+// Fused snake activation: dst = x + beta_scale[c] * sin(alpha[c] * x)^2
+// Operates on contiguous (b, c, l) tensors with per-channel alpha/beta_scale.
+// ============================================================================
+
+template<typename T>
+__device__ void snake(
+    const size_t numel,
+    const size_t channels,
+    const size_t row_len,
+    const T *src,
+    const T *alpha,
+    const T *beta_scale,
+    T *dst
+) {
+    const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= numel) return;
+    const size_t c = (idx / row_len) % channels;
+    const float x = to_float(src[idx]);
+    const float s = sinf(to_float(alpha[c]) * x);
+    dst[idx] = from_float<T>(x + to_float(beta_scale[c]) * s * s);
+}
+
+#define SNAKE_KERNEL(TYPENAME, RUST_NAME) \
+extern "C" __global__ void snake_##RUST_NAME( \
+    const size_t numel, \
+    const size_t channels, \
+    const size_t row_len, \
+    const TYPENAME *src, \
+    const TYPENAME *alpha, \
+    const TYPENAME *beta_scale, \
+    TYPENAME *dst \
+) { \
+    snake<TYPENAME>(numel, channels, row_len, src, alpha, beta_scale, dst); \
+}
+
+#if __CUDA_ARCH__ >= 800
+SNAKE_KERNEL(__nv_bfloat16, bf16)
+#endif
+
+#if __CUDA_ARCH__ >= 530
+SNAKE_KERNEL(__half, f16)
+#endif
+
+SNAKE_KERNEL(float, f32)

--- a/xn-core/cuda-kernels/conv.cu
+++ b/xn-core/cuda-kernels/conv.cu
@@ -81,6 +81,7 @@ __device__ void col2im1d_kernel(
     const size_t k_size,
     const size_t stride,
     const T *src,
+    const T *bias, // per-channel bias fused into the epilogue, may be nullptr
     T *dst
 ) {
     const size_t b = blockIdx.z;
@@ -112,7 +113,7 @@ __device__ void col2im1d_kernel(
             }
 
             size_t dst_idx = b * c_out * l_out + (size_t)c_idx * l_out + (size_t)l_out_idx;
-            dst[dst_idx] = sum;
+            dst[dst_idx] = (bias == nullptr) ? sum : sum + bias[c_idx];
         }
     }
 }
@@ -247,6 +248,7 @@ __device__ void transpose_blc_to_bcl(
     const size_t length,
     const size_t channels,
     const T *src,
+    const T *bias, // per-channel bias fused into the epilogue, may be nullptr
     T *dst
 ) {
     __shared__ T tile[TILE_DIM][TILE_DIM + 1];
@@ -270,8 +272,11 @@ __device__ void transpose_blc_to_bcl(
     int c2 = blockIdx.x * TILE_DIM + threadIdx.y;
 
     for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
-        if (l2 < (int)length && (c2 + j) < (int)channels)
-            dst[b * lc + (c2 + j) * length + l2] = tile[threadIdx.x][threadIdx.y + j];
+        if (l2 < (int)length && (c2 + j) < (int)channels) {
+            T v = tile[threadIdx.x][threadIdx.y + j];
+            if (bias != nullptr) v += bias[c2 + j];
+            dst[b * lc + (c2 + j) * length + l2] = v;
+        }
     }
 }
 
@@ -343,7 +348,19 @@ extern "C" __global__ void col2im1d_##RUST_NAME( \
     const TYPENAME *src, \
     TYPENAME *dst \
 ) { \
-    col2im1d_kernel<TYPENAME>(l_in, c_out, l_out, k_size, stride, src, dst); \
+    col2im1d_kernel<TYPENAME>(l_in, c_out, l_out, k_size, stride, src, (const TYPENAME*)nullptr, dst); \
+} \
+extern "C" __global__ void col2im1d_bias_##RUST_NAME( \
+    const size_t l_in, \
+    const size_t c_out, \
+    const size_t l_out, \
+    const size_t k_size, \
+    const size_t stride, \
+    const TYPENAME *src, \
+    const TYPENAME *bias, \
+    TYPENAME *dst \
+) { \
+    col2im1d_kernel<TYPENAME>(l_in, c_out, l_out, k_size, stride, src, bias, dst); \
 }
 
 #define CONV1D_DIRECT_OP(TYPENAME, RUST_NAME) \
@@ -394,7 +411,16 @@ extern "C" __global__ void transpose_blc_bcl_##RUST_NAME( \
     const TYPENAME *src, \
     TYPENAME *dst \
 ) { \
-    transpose_blc_to_bcl<TYPENAME>(length, channels, src, dst); \
+    transpose_blc_to_bcl<TYPENAME>(length, channels, src, (const TYPENAME*)nullptr, dst); \
+} \
+extern "C" __global__ void transpose_blc_bcl_bias_##RUST_NAME( \
+    const size_t length, \
+    const size_t channels, \
+    const TYPENAME *src, \
+    const TYPENAME *bias, \
+    TYPENAME *dst \
+) { \
+    transpose_blc_to_bcl<TYPENAME>(length, channels, src, bias, dst); \
 }
 
 #define TRANSPOSE_BCL_BLC_OP(TYPENAME, RUST_NAME) \

--- a/xn-core/src/backend.rs
+++ b/xn-core/src/backend.rs
@@ -184,6 +184,19 @@ pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
         eps: f32,
     ) -> Result<()>;
 
+    /// Fused snake activation: dst = x + beta_scale[c] * sin(alpha[c] * x)^2
+    /// src/dst are contiguous with `row_len` elements per channel row and
+    /// `channels` channels; alpha and beta_scale hold one value per channel.
+    fn snake<T: crate::WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        alpha: &Self::Storage<T>,
+        beta_scale: &Self::Storage<T>,
+        channels: usize,
+        row_len: usize,
+        numel: usize,
+    ) -> Result<()>;
+
     /// Layer normalization.
     /// Normalizes over the last dimension using mean and variance.
     /// When `remove_mean` is true: y = (x - mean) / sqrt(variance + eps) * weight + bias

--- a/xn-core/src/backend.rs
+++ b/xn-core/src/backend.rs
@@ -342,4 +342,80 @@ pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
         output_padding: usize,
         groups: usize,
     ) -> Result<()>;
+
+    /// Same as [`Backend::conv1d`], but backends that can fuse the
+    /// per-channel bias into the convolution epilogue apply it and return
+    /// `Ok(true)`. The default implementation ignores the bias and returns
+    /// `Ok(false)`, in which case the caller must apply it separately.
+    #[allow(clippy::too_many_arguments)]
+    fn conv1d_with_bias<T: crate::WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        _bias: Option<&Self::Storage<T>>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        Self::conv1d(
+            dst,
+            src,
+            kernel,
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+        )?;
+        Ok(false)
+    }
+
+    /// Same as [`Backend::conv_transpose1d`], with the bias-fusion contract
+    /// of [`Backend::conv1d_with_bias`].
+    #[allow(clippy::too_many_arguments)]
+    fn conv_transpose1d_with_bias<T: crate::WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        _bias: Option<&Self::Storage<T>>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        output_padding: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        Self::conv_transpose1d(
+            dst,
+            src,
+            kernel,
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            output_padding,
+            groups,
+        )?;
+        Ok(false)
+    }
 }

--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -958,6 +958,32 @@ impl crate::Backend for crate::CpuDevice {
         Ok(())
     }
 
+    fn snake<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        alpha: &Self::Storage<T>,
+        beta_scale: &Self::Storage<T>,
+        channels: usize,
+        row_len: usize,
+        numel: usize,
+    ) -> Result<()> {
+        let src = &src[..numel];
+        let dst = &mut dst[..numel];
+        src.par_chunks(row_len).zip(dst.par_chunks_mut(row_len)).enumerate().for_each(
+            |(row, (src, dst))| {
+                let c = row % channels;
+                let alpha = alpha[c].to_f32();
+                let beta_scale = beta_scale[c].to_f32();
+                for (d, s) in dst.iter_mut().zip(src.iter()) {
+                    let x = (*s).to_f32();
+                    let sin = (alpha * x).sin();
+                    *d = T::from_f32(x + beta_scale * sin * sin)
+                }
+            },
+        );
+        Ok(())
+    }
+
     fn layer_norm<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -1915,6 +1915,7 @@ impl crate::Backend for Device {
                 dst,
                 src,
                 kernel,
+                None,
                 batch,
                 in_channels,
                 out_channels,
@@ -1972,6 +1973,7 @@ impl crate::Backend for Device {
                 dst,
                 src,
                 kernel,
+                None,
                 batch,
                 in_channels,
                 out_channels,
@@ -1999,6 +2001,111 @@ impl crate::Backend for Device {
             )
         }
     }
+
+    fn conv1d_with_bias<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        bias: Option<&Self::Storage<T>>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        if groups == 1 {
+            conv1d_im2col(
+                dst,
+                src,
+                kernel,
+                bias.map(|b| &b.data),
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+            )?;
+            Ok(bias.is_some())
+        } else {
+            conv1d_direct(
+                dst,
+                src,
+                kernel,
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                groups,
+            )?;
+            Ok(false)
+        }
+    }
+
+    fn conv_transpose1d_with_bias<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        bias: Option<&Self::Storage<T>>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        output_padding: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        let can_use_col2im = groups == 1 && padding == 0 && output_padding == 0;
+        if can_use_col2im {
+            conv_transpose1d_col2im(
+                dst,
+                src,
+                kernel,
+                bias.map(|b| &b.data),
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+            )?;
+            Ok(bias.is_some())
+        } else {
+            conv_transpose1d_direct(
+                dst,
+                src,
+                kernel,
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+                padding,
+                output_padding,
+                groups,
+            )?;
+            Ok(false)
+        }
+    }
 }
 
 // ============================================================================
@@ -2009,6 +2116,7 @@ fn conv1d_im2col<T: WithDTypeF>(
     dst: &mut Storage<T>,
     src: &Storage<T>,
     kernel: &Storage<T>,
+    bias: Option<&CudaSlice<T>>,
     batch: usize,
     in_channels: usize,
     out_channels: usize,
@@ -2065,8 +2173,12 @@ fn conv1d_im2col<T: WithDTypeF>(
     // Which gives us result in row-major as [L_out, out_channels]
     conv1d_gemm(&dst.device, &col, &kernel.data, &mut result, batch, out_length, out_channels, k)?;
 
-    // Step 3: Transpose from [B, L_out, out_channels] to [B, out_channels, L_out]
-    let kname = format!("transpose_blc_bcl_{}", T::DTYPE.cuda_name());
+    // Step 3: Transpose from [B, L_out, out_channels] to [B, out_channels, L_out],
+    // fusing the per-channel bias into the store when provided.
+    let kname = match bias {
+        Some(_) => format!("transpose_blc_bcl_bias_{}", T::DTYPE.cuda_name()),
+        None => format!("transpose_blc_bcl_{}", T::DTYPE.cuda_name()),
+    };
     let func = dst.device.get_func(&kname, PTXModule::Conv)?;
     let cfg = LaunchConfig {
         grid_dim: (
@@ -2082,6 +2194,9 @@ fn conv1d_im2col<T: WithDTypeF>(
     launch_args.arg(&out_length);
     launch_args.arg(&out_channels);
     launch_args.arg(&result);
+    if let Some(bias) = bias {
+        launch_args.arg(bias);
+    }
     launch_args.arg(&mut dst.data);
     unsafe { launch_args.launch(cfg) }?;
 
@@ -2329,6 +2444,7 @@ fn conv_transpose1d_col2im<T: WithDTypeF>(
     dst: &mut Storage<T>,
     src: &Storage<T>,
     kernel: &Storage<T>,
+    bias: Option<&CudaSlice<T>>,
     batch: usize,
     in_channels: usize,
     out_channels: usize,
@@ -2387,10 +2503,13 @@ fn conv_transpose1d_col2im<T: WithDTypeF>(
         in_channels,
     )?;
 
-    // Step 3: Col2Im transformation
+    // Step 3: Col2Im transformation, fusing the per-channel bias when provided
     // col: [B, L_in, C_out * K] = [B, L_in, C_out, K]
     // output: [B, C_out, L_out]
-    let kname = format!("col2im1d_{}", T::DTYPE.cuda_name());
+    let kname = match bias {
+        Some(_) => format!("col2im1d_bias_{}", T::DTYPE.cuda_name()),
+        None => format!("col2im1d_{}", T::DTYPE.cuda_name()),
+    };
     let func = dst.device.get_func(&kname, PTXModule::Conv)?;
     let cfg = LaunchConfig {
         grid_dim: (
@@ -2409,6 +2528,9 @@ fn conv_transpose1d_col2im<T: WithDTypeF>(
     launch_args.arg(&kernel_size);
     launch_args.arg(&stride);
     launch_args.arg(&col);
+    if let Some(bias) = bias {
+        launch_args.arg(bias);
+    }
     launch_args.arg(&mut dst.data);
     unsafe { launch_args.launch(cfg) }?;
 

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -1487,6 +1487,30 @@ impl crate::Backend for Device {
         Ok(())
     }
 
+    fn snake<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        alpha: &Self::Storage<T>,
+        beta_scale: &Self::Storage<T>,
+        channels: usize,
+        row_len: usize,
+        numel: usize,
+    ) -> Result<()> {
+        let kname = kernel_name::<T>("snake");
+        let func = dst.device.get_func(&kname, PTXModule::Broadcast)?;
+        let cfg = LaunchConfig::for_num_elems(numel as u32);
+        let mut launch_args = dst.device.stream.launch_builder(&func);
+        launch_args.arg(&numel);
+        launch_args.arg(&channels);
+        launch_args.arg(&row_len);
+        launch_args.arg(&src.data);
+        launch_args.arg(&alpha.data);
+        launch_args.arg(&beta_scale.data);
+        launch_args.arg(&mut dst.data);
+        unsafe { launch_args.launch(cfg) }?;
+        Ok(())
+    }
+
     fn layer_norm<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/src/inplace_ops.rs
+++ b/xn-core/src/inplace_ops.rs
@@ -376,6 +376,41 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         Ok(())
     }
 
+    /// Fused snake activation: self = src + beta_scale[c] * sin(alpha[c] * src)^2
+    /// src has shape (b, c, l); alpha and beta_scale have c elements each
+    /// (trailing singleton dims are accepted, e.g. (1, c, 1)).
+    pub fn snake_(&self, src: &Self, alpha: &Self, beta_scale: &Self) -> Result<()> {
+        self.check_not_same_storage(src, "snake_")?;
+        self.check_not_same_storage(alpha, "snake_")?;
+        self.check_not_same_storage(beta_scale, "snake_")?;
+        check_same_shape(&self.shape, &src.shape, "snake_ src")?;
+        let (_b, channels, row_len) = match *self.shape.dims() {
+            [b, c, l] => (b, c, l),
+            _ => crate::bail!("snake_ expects a 3D tensor, got shape {:?}", self.shape()),
+        };
+        if alpha.elem_count() != channels || beta_scale.elem_count() != channels {
+            crate::bail!(
+                "snake_ expects alpha/beta_scale with {channels} elements, got {:?} and {:?}",
+                alpha.shape(),
+                beta_scale.shape()
+            );
+        }
+        let mut dst = self.storage_mut()?;
+        let src_data = src.storage()?;
+        let alpha_data = alpha.storage()?;
+        let beta_scale_data = beta_scale.storage()?;
+        B::snake(
+            &mut *dst,
+            &*src_data,
+            &*alpha_data,
+            &*beta_scale_data,
+            channels,
+            row_len,
+            self.elem_count(),
+        )?;
+        Ok(())
+    }
+
     pub fn layer_norm_(
         &self,
         src: &Self,

--- a/xn-core/src/inplace_ops.rs
+++ b/xn-core/src/inplace_ops.rs
@@ -852,6 +852,98 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
             groups,
         )
     }
+
+    /// Conv1d with the bias-fusion contract of [`crate::Backend::conv1d_with_bias`]:
+    /// returns whether the backend applied the bias.
+    #[allow(clippy::too_many_arguments)]
+    pub fn conv1d_with_bias_(
+        &self,
+        src: &Self,
+        kernel: &Self,
+        bias: Option<&Self>,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        self.check_not_same_storage(src, "conv1d_")?;
+        self.check_not_same_storage(kernel, "conv1d_")?;
+        let src_dims = src.dims();
+        let kernel_dims = kernel.dims();
+        let batch = src_dims[0];
+        let in_channels = src_dims[1];
+        let length = src_dims[2];
+        let out_channels = kernel_dims[0];
+        let kernel_size = kernel_dims[2];
+        let out_length = (length + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1;
+
+        let mut dst = self.storage_mut()?;
+        let src_data = src.storage()?;
+        let kernel_data = kernel.storage()?;
+        let bias_data = bias.map(|b| b.storage()).transpose()?;
+        B::conv1d_with_bias(
+            &mut *dst,
+            &*src_data,
+            &*kernel_data,
+            bias_data.as_deref(),
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+        )
+    }
+
+    /// ConvTranspose1d with the bias-fusion contract of
+    /// [`crate::Backend::conv_transpose1d_with_bias`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn conv_transpose1d_with_bias_(
+        &self,
+        src: &Self,
+        kernel: &Self,
+        bias: Option<&Self>,
+        stride: usize,
+        padding: usize,
+        output_padding: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        self.check_not_same_storage(src, "conv_transpose1d_")?;
+        self.check_not_same_storage(kernel, "conv_transpose1d_")?;
+        let src_dims = src.dims();
+        let kernel_dims = kernel.dims();
+        let batch = src_dims[0];
+        let in_channels = src_dims[1];
+        let length = src_dims[2];
+        let out_channels = kernel_dims[1] * groups;
+        let kernel_size = kernel_dims[2];
+        let out_length = (length - 1) * stride + kernel_size + output_padding - 2 * padding;
+
+        let mut dst = self.storage_mut()?;
+        let src_data = src.storage()?;
+        let kernel_data = kernel.storage()?;
+        let bias_data = bias.map(|b| b.storage()).transpose()?;
+        B::conv_transpose1d_with_bias(
+            &mut *dst,
+            &*src_data,
+            &*kernel_data,
+            bias_data.as_deref(),
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            output_padding,
+            groups,
+        )
+    }
 }
 
 /// Compute broadcast strides for lhs and rhs given the output shape.

--- a/xn-core/src/metal_backend/backend_impl.rs
+++ b/xn-core/src/metal_backend/backend_impl.rs
@@ -539,6 +539,18 @@ impl crate::Backend for Device {
         dst.device.dispatch(&format!("softmax_{dt}"), &[src.buf(), dst.buf()], &push, d as u32)
     }
 
+    fn snake<T: WithDTypeF>(
+        _dst: &mut Self::Storage<T>,
+        _src: &Self::Storage<T>,
+        _alpha: &Self::Storage<T>,
+        _beta_scale: &Self::Storage<T>,
+        _channels: usize,
+        _row_len: usize,
+        _numel: usize,
+    ) -> Result<()> {
+        crate::bail!("snake is not implemented for this backend")
+    }
+
     fn rms_norm<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/src/ops.rs
+++ b/xn-core/src/ops.rs
@@ -248,6 +248,15 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         Ok(result)
     }
 
+    /// Fused snake activation: y = x + beta_scale[c] * sin(alpha[c] * x)^2
+    /// self has shape (b, c, l); alpha and beta_scale have c elements each.
+    #[tracing::instrument(skip_all)]
+    pub fn snake(&self, alpha: &Self, beta_scale: &Self) -> Result<Self> {
+        let result = unsafe { Tensor::alloc_uninit(self.shape.clone(), self.device()) }?;
+        result.snake_(self, alpha, beta_scale)?;
+        Ok(result)
+    }
+
     #[tracing::instrument(skip_all)]
     pub fn layer_norm(&self, weight: &Self, bias: &Self, eps: f32) -> Result<Self> {
         self.layer_norm_rm(weight, bias, eps, true)

--- a/xn-core/src/ops.rs
+++ b/xn-core/src/ops.rs
@@ -322,11 +322,6 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         // Compute output length
         let out_length = (length + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1;
 
-        let mut result =
-            unsafe { Tensor::alloc_uninit((batch, out_channels, out_length), self.device()) }?;
-        result.conv1d_(self, kernel, stride, padding, dilation, groups)?;
-
-        // Add bias if provided
         if let Some(bias) = bias {
             let bias_dims = bias.dims();
             if bias_dims != [out_channels] {
@@ -335,6 +330,17 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
                     bias.shape()
                 );
             }
+        }
+
+        let mut result =
+            unsafe { Tensor::alloc_uninit((batch, out_channels, out_length), self.device()) }?;
+        let bias_applied =
+            result.conv1d_with_bias_(self, kernel, bias, stride, padding, dilation, groups)?;
+
+        // Add bias separately if the backend did not fuse it
+        if let Some(bias) = bias
+            && !bias_applied
+        {
             // Reshape bias to (1, out_channels, 1) for broadcasting
             let bias = bias.reshape((1, out_channels, 1))?;
             result = result.broadcast_add(&bias)?;
@@ -375,11 +381,6 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         // out_length = (length - 1) * stride - 2 * padding + kernel_size + output_padding
         let out_length = (length - 1) * stride + kernel_size + output_padding - 2 * padding;
 
-        let mut result =
-            unsafe { Tensor::alloc_uninit((batch, out_channels, out_length), self.device()) }?;
-        result.conv_transpose1d_(self, kernel, stride, padding, output_padding, groups)?;
-
-        // Add bias if provided
         if let Some(bias) = bias {
             let bias_dims = bias.dims();
             if bias_dims != [out_channels] {
@@ -388,6 +389,24 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
                     bias.shape()
                 );
             }
+        }
+
+        let mut result =
+            unsafe { Tensor::alloc_uninit((batch, out_channels, out_length), self.device()) }?;
+        let bias_applied = result.conv_transpose1d_with_bias_(
+            self,
+            kernel,
+            bias,
+            stride,
+            padding,
+            output_padding,
+            groups,
+        )?;
+
+        // Add bias separately if the backend did not fuse it
+        if let Some(bias) = bias
+            && !bias_applied
+        {
             // Reshape bias to (1, out_channels, 1) for broadcasting
             let bias = bias.reshape((1, out_channels, 1))?;
             result = result.broadcast_add(&bias)?;

--- a/xn-core/src/vulkan_backend/backend_impl.rs
+++ b/xn-core/src/vulkan_backend/backend_impl.rs
@@ -569,6 +569,18 @@ impl crate::Backend for Device {
         dst.device.dispatch(&format!("softmax_{dt}"), &[src.buffer, dst.buffer], &push, d as u32)
     }
 
+    fn snake<T: WithDTypeF>(
+        _dst: &mut Self::Storage<T>,
+        _src: &Self::Storage<T>,
+        _alpha: &Self::Storage<T>,
+        _beta_scale: &Self::Storage<T>,
+        _channels: usize,
+        _row_len: usize,
+        _numel: usize,
+    ) -> Result<()> {
+        crate::bail!("snake is not implemented for this backend")
+    }
+
     fn rms_norm<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/src/webgpu_backend/backend_impl.rs
+++ b/xn-core/src/webgpu_backend/backend_impl.rs
@@ -512,6 +512,18 @@ impl crate::Backend for Device {
         dst.device.dispatch(&format!("softmax_{dt}"), &[&src.buffer, &dst.buffer], &push, d as u32)
     }
 
+    fn snake<T: WithDTypeF>(
+        _dst: &mut Self::Storage<T>,
+        _src: &Self::Storage<T>,
+        _alpha: &Self::Storage<T>,
+        _beta_scale: &Self::Storage<T>,
+        _channels: usize,
+        _row_len: usize,
+        _numel: usize,
+    ) -> Result<()> {
+        crate::bail!("snake is not implemented for this backend")
+    }
+
     fn rms_norm<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1831,3 +1831,44 @@ fn test_snake_cuda() -> Result<()> {
     let device = xn::cuda_backend::Device::new(0)?;
     test_snake_impl(&device)
 }
+
+// Conv bias fusion: conv with bias must match conv without bias + broadcast
+// add, on every backend (fused epilogue on cuda, fallback path elsewhere).
+fn test_conv_bias_fusion_impl<B: Backend>(device: &B) -> Result<()> {
+    let (b, c_in, c_out, l, k) = (2, 5, 7, 13, 3);
+    let xs: Vec<f32> =
+        (0..b * c_in * l).map(|i| ((i * 37 + 11) % 23) as f32 * 0.17 - 1.9).collect();
+    let w: Vec<f32> =
+        (0..c_out * c_in * k).map(|i| ((i * 29 + 5) % 19) as f32 * 0.11 - 1.0).collect();
+    let bias: Vec<f32> = (0..c_out).map(|i| i as f32 * 0.73 - 2.1).collect();
+
+    let xs: Tensor<f32, B> = Tensor::from_vec(xs, vec![b, c_in, l], device)?;
+    let w_t: Tensor<f32, B> = Tensor::from_vec(w.clone(), vec![c_out, c_in, k], device)?;
+    let bias_t: Tensor<f32, B> = Tensor::from_vec(bias, vec![c_out], device)?;
+
+    let fused = xs.conv1d(&w_t, Some(&bias_t), 1, 1, 1, 1)?;
+    let unfused =
+        xs.conv1d(&w_t, None, 1, 1, 1, 1)?.broadcast_add(&bias_t.reshape((1, c_out, 1))?)?;
+    assert_eq!(fused.to_vec()?, unfused.to_vec()?, "conv1d bias mismatch");
+
+    // conv_transpose1d: kernel layout (c_in, c_out, k), stride 2 upsampling
+    let wt: Tensor<f32, B> = Tensor::from_vec(w, vec![c_in, c_out, k], device)?;
+    let fused = xs.conv_transpose1d(&wt, Some(&bias_t), 2, 0, 0, 1)?;
+    let unfused = xs
+        .conv_transpose1d(&wt, None, 2, 0, 0, 1)?
+        .broadcast_add(&bias_t.reshape((1, c_out, 1))?)?;
+    assert_eq!(fused.to_vec()?, unfused.to_vec()?, "conv_transpose1d bias mismatch");
+    Ok(())
+}
+
+#[test]
+fn test_conv_bias_fusion_cpu() -> Result<()> {
+    test_conv_bias_fusion_impl(&xn::CPU)
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_conv_bias_fusion_cuda() -> Result<()> {
+    let device = xn::cuda_backend::Device::new(0)?;
+    test_conv_bias_fusion_impl(&device)
+}

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1787,3 +1787,47 @@ fn test_matmul_batched_strided_impl<B: Backend>(dev: &B) -> Result<()> {
     Ok(())
 }
 test_all_backends!(test_matmul_batched_strided, test_matmul_batched_strided_impl);
+
+// Fused snake activation: check against the composed op sequence it replaces
+// (broadcast_mul -> sin -> sqr -> broadcast_mul -> add) and a host reference.
+fn test_snake_impl<B: Backend>(device: &B) -> Result<()> {
+    let (b, c, l) = (2, 3, 17);
+    let xs: Vec<f32> = (0..b * c * l)
+        .map(|i| ((i as f32) * 0.37 - 10.0) * ((i % 7) as f32 * 0.21 + 0.1))
+        .collect();
+    let alpha: Vec<f32> = (0..c).map(|i| 0.5 + i as f32 * 0.8).collect();
+    let beta_scale: Vec<f32> = (0..c).map(|i| 1.7 - i as f32 * 0.4).collect();
+
+    let xs_t: Tensor<f32, B> = Tensor::from_vec(xs.clone(), vec![b, c, l], device)?;
+    let alpha_t: Tensor<f32, B> = Tensor::from_vec(alpha.clone(), vec![1, c, 1], device)?;
+    let beta_t: Tensor<f32, B> = Tensor::from_vec(beta_scale.clone(), vec![1, c, 1], device)?;
+
+    let fused = xs_t.snake(&alpha_t, &beta_t)?.to_vec()?;
+    let sin2 = xs_t.broadcast_mul(&alpha_t)?.sin()?.sqr()?;
+    let composed = xs_t.add(&sin2.broadcast_mul(&beta_t)?)?.to_vec()?;
+
+    for (i, (f, cm)) in fused.iter().zip(composed.iter()).enumerate() {
+        assert!((f - cm).abs() <= 1e-5 * cm.abs().max(1.0), "idx {i}: fused {f} composed {cm}");
+        let ch = (i / l) % c;
+        let x = xs[i];
+        let s = (alpha[ch] * x).sin();
+        let reference = x + beta_scale[ch] * s * s;
+        assert!(
+            (f - reference).abs() <= 1e-5 * reference.abs().max(1.0),
+            "idx {i}: fused {f} reference {reference}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_snake_cpu() -> Result<()> {
+    test_snake_impl(&xn::CPU)
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_snake_cuda() -> Result<()> {
+    let device = xn::cuda_backend::Device::new(0)?;
+    test_snake_impl(&device)
+}


### PR DESCRIPTION
Two pointwise-fusion kernels for the mimi seanet decoder, both measured on the
streaming mimi decode step. Together they take that step **−28% at batch 32**
with no change to what the model computes.

## What's here

**1. Fused snake activation** (`Tensor::snake` / `snake_`, `Backend::snake`).
`SnakeBeta` currently expands to a five-kernel chain per activation
(`broadcast_mul` → `sin` → `sqr` → `broadcast_mul` → `add`), and the qwen mimi
decoder runs ~36 of them per step. This computes
`y = x + beta_scale[c] * sin(alpha[c] * x)^2` in one pass over the tensor.
CUDA and CPU implementations are real; metal/webgpu/vulkan bail.

**2. Conv bias folded into the conv epilogue.** The per-channel bias add was a
separate broadcast pass over the whole conv output; it now rides along in the
transpose/col2im epilogue kernel that already writes that output. Backends
advertise support via `conv1d_with_bias` / `conv_transpose1d_with_bias`, which
return whether the bias was applied so `Tensor::conv1d` falls back to the
broadcast add otherwise. Only CUDA overrides them. Always on, no flag.

## Measured impact

Mimi decode step, p50 ms, RTX 4080 SUPER (sm_89), model `tts-af440bf5.1`
(48 kHz qwen decoder), 200 steps after 20 warmup, all measured in one session:

| arm | b16 | b32 |
|---|---|---|
| xn 0.2.2 (`main`) | 14.23 | 28.16 |
| + conv-bias epilogue | 13.30 | 26.15 |
| + fused snake | **10.54** | **20.19** |
| | **−26%** | **−28%** |

Marginal contribution at b32: bias epilogue −2.01 ms, fused snake −5.96 ms.
Note the split is order-dependent — fusing either one removes both kernel time
and the launch gaps around it, so measured second, each scores lower than it
would measured first. The endpoints are the solid numbers, and run-to-run
variance on this box is about ±0.3 ms.

Where it lands: the entire saving is in the seanet phase (26.06 → 20.09 ms at
b32 by per-phase host timers); dequant, adapter, transformer and upsample are
unchanged. After both rungs the unfused pointwise residue is 0.9 ms — 94
`binary_add_f32` launches, the resnet residual and streaming-overlap adds —
against 0.62 ms for the equivalent fused pointwise work in an XLA-compiled
version of the same model. So this bucket is now effectively closed; folding
the residual adds in too would need a residual argument threaded through
`Tensor::conv1d` for roughly another 0.5 ms, which did not look worth the API
change.

## Numerics

The bias fusion is **bit-exact** — same operands, same order, just a different
kernel writing the sum (`test_conv_bias_fusion_{cpu,cuda}`).

The fused snake is **not** bit-exact: it evaluates the identical formula, but
`beta * s * s` associates left-to-right where the composed chain squares first
(`(s*s) * beta`). `test_snake_{cpu,cuda}` assert a 1e-5 relative tolerance
against both the composed chain and an independently computed scalar reference.
Worth knowing if anything downstream compares audio bit-for-bit against a
pre-existing reference.

## Consumers

The bias fusion needs no caller change — anything already passing bias to
`Tensor::conv1d` picks it up on upgrade. The snake kernel does: callers must
switch to `.snake(alpha, beta_scale)` (in gradium-serve that is
`SnakeBeta::forward` in `xn-moshi/src/seanet.rs`, currently prototyped behind an
env gate). That follow-up needs 0.2.3 published, so this PR bumps the workspace
version, same sequencing as #56.

## Why only these two

These are rungs 1 and 2 of four from a mimi decode investigation comparing xn
against an XLA-compiled build of the same model at b32
(https://claude.ai/code/artifact/f02a912c-3503-437f-9d14-92a98df71101). The
other two are deliberately not here:

- **CUDA-graph capture of the decode step** measures a further −6.4 ms at b32,
  the largest single win, but is not shippable yet: it needs frees deferred
  rather than leaked while a capture is in flight, rope positions moved to a
  device buffer (absolute positions never repeat, so the htod replay cache
  cannot serve them), and a record pass covering the decoder transformer's
  72-step scatter-index cycle.
- **Direct cuDNN convolutions** buy only −0.8 ms at b32 and *cost* 1.3 ms at
  b16. Verified by kernel identity that xn and XLA already request the same
  thing — both land on the same `sm80_xmma_fprop_implicit_gemm_tf32f32_*`
  engines, both are already TF32, and both pay the same ~50 NCHW↔NHWC converts
  per step — so that ceiling is real rather than a misconfiguration. Not worth a
  libcudnn dependency.

## Self-review

- [x] Tests pass: full `tensor_tests` suite green with `--features cuda`
      (212 passed), including the four new snake/bias-fusion tests.
- [x] Measurements come from the code in this PR, on a branch built off current
      `main`, with the baseline arm re-measured in the same session rather than
      quoted from earlier runs.
- [x] Scope is limited to the two fusions plus the version bump; the
      graph-capture and cuDNN experiments from the same investigation are left
      out, and the `XN_TF32` global cublas math-mode toggle that rode along in
      the original bias commit was dropped as superseded by 0.2.2's per-call
      `gemm_ex` precision handling.
- [x] Numerics characterized above, including the one case that is not
      bit-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017phHCJvH9dxZFyV2Wv91BL
