### PR TITLE
Prototype: mimi decode 27.9 -> 10.6 ms at b32 (fusion, CUDA-graph capture, per-shape conv routing)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ash = "0.38"
 bindgen_cuda = "0.1.6"
 byteorder = "1"
 clap = { version = "4", features = ["derive"] }
-cudarc = { version = "0.19.4", features = ["std", "cublas", "cublaslt", "curand", "driver", "nvrtc", "f16", "cuda-version-from-build-system", "dynamic-linking"] }
+cudarc = { version = "0.19.4", features = ["std", "cublas", "cublaslt", "cudnn", "curand", "driver", "nvrtc", "f16", "cuda-version-from-build-system", "dynamic-linking"] }
 gemm = { version = "0.19.0", features = ["wasm-simd128-enable"] }
 half = { version = "2.7.1", features = ["num-traits"] }
 hf-hub = { version = "0.5", default-features = false, features = ["ureq"] }

--- a/xn-core/cuda-kernels/broadcast.cu
+++ b/xn-core/cuda-kernels/broadcast.cu
@@ -415,3 +415,59 @@ SNAKE_KERNEL(__half, f16)
 #endif
 
 SNAKE_KERNEL(float, f32)
+
+// ============================================================================
+// Snake activation writing into a window of a longer destination row:
+//   dst[b, c, dst_offset + l] = snake(src[b, c, l])
+// Used to fuse the activation into the streaming-conv input concatenation: the
+// state prefix is copied into dst[.., ..dst_offset] and the new input is
+// activated straight into the remainder, so the activation costs no extra pass.
+// ============================================================================
+
+template<typename T>
+__device__ void snake_offset(
+    const size_t numel,
+    const size_t channels,
+    const size_t src_len,
+    const size_t dst_len,
+    const size_t dst_offset,
+    const T *src,
+    const T *alpha,
+    const T *beta_scale,
+    T *dst
+) {
+    const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= numel) return;
+    const size_t l = idx % src_len;
+    const size_t c = (idx / src_len) % channels;
+    const size_t b = idx / (src_len * channels);
+    const float x = to_float(src[idx]);
+    const float s = sinf(to_float(alpha[c]) * x);
+    const size_t dst_idx = (b * channels + c) * dst_len + dst_offset + l;
+    dst[dst_idx] = from_float<T>(x + to_float(beta_scale[c]) * s * s);
+}
+
+#define SNAKE_OFFSET_KERNEL(TYPENAME, RUST_NAME) \
+extern "C" __global__ void snake_offset_##RUST_NAME( \
+    const size_t numel, \
+    const size_t channels, \
+    const size_t src_len, \
+    const size_t dst_len, \
+    const size_t dst_offset, \
+    const TYPENAME *src, \
+    const TYPENAME *alpha, \
+    const TYPENAME *beta_scale, \
+    TYPENAME *dst \
+) { \
+    snake_offset<TYPENAME>(numel, channels, src_len, dst_len, dst_offset, src, alpha, beta_scale, dst); \
+}
+
+#if __CUDA_ARCH__ >= 800
+SNAKE_OFFSET_KERNEL(__nv_bfloat16, bf16)
+#endif
+
+#if __CUDA_ARCH__ >= 530
+SNAKE_OFFSET_KERNEL(__half, f16)
+#endif
+
+SNAKE_OFFSET_KERNEL(float, f32)

--- a/xn-core/cuda-kernels/broadcast.cu
+++ b/xn-core/cuda-kernels/broadcast.cu
@@ -369,3 +369,49 @@ BROADCAST_ALL_OPS(__half, f16)
 BROADCAST_ALL_OPS(float, f32)
 BROADCAST_ALL_OPS(int64_t, i64)
 BROADCAST_ALL_OPS(uint8_t, u8)
+
+// ============================================================================
+// Fused snake activation: dst = x + beta_scale[c] * sin(alpha[c] * x)^2
+// Operates on contiguous (b, c, l) tensors with per-channel alpha/beta_scale.
+// ============================================================================
+
+template<typename T>
+__device__ void snake(
+    const size_t numel,
+    const size_t channels,
+    const size_t row_len,
+    const T *src,
+    const T *alpha,
+    const T *beta_scale,
+    T *dst
+) {
+    const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= numel) return;
+    const size_t c = (idx / row_len) % channels;
+    const float x = to_float(src[idx]);
+    const float s = sinf(to_float(alpha[c]) * x);
+    dst[idx] = from_float<T>(x + to_float(beta_scale[c]) * s * s);
+}
+
+#define SNAKE_KERNEL(TYPENAME, RUST_NAME) \
+extern "C" __global__ void snake_##RUST_NAME( \
+    const size_t numel, \
+    const size_t channels, \
+    const size_t row_len, \
+    const TYPENAME *src, \
+    const TYPENAME *alpha, \
+    const TYPENAME *beta_scale, \
+    TYPENAME *dst \
+) { \
+    snake<TYPENAME>(numel, channels, row_len, src, alpha, beta_scale, dst); \
+}
+
+#if __CUDA_ARCH__ >= 800
+SNAKE_KERNEL(__nv_bfloat16, bf16)
+#endif
+
+#if __CUDA_ARCH__ >= 530
+SNAKE_KERNEL(__half, f16)
+#endif
+
+SNAKE_KERNEL(float, f32)

--- a/xn-core/cuda-kernels/conv.cu
+++ b/xn-core/cuda-kernels/conv.cu
@@ -267,6 +267,7 @@ __device__ void transpose_blc_to_bcl(
     const T *bias, // per-channel bias fused into the epilogue, may be nullptr
     const T *snake_alpha,     // fused snake activation, may be nullptr
     const T *snake_beta,
+    const T *residual,        // fused residual add, may be nullptr
     T *dst
 ) {
     __shared__ T tile[TILE_DIM][TILE_DIM + 1];
@@ -291,11 +292,16 @@ __device__ void transpose_blc_to_bcl(
 
     for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
         if (l2 < (int)length && (c2 + j) < (int)channels) {
+            const size_t dst_idx = b * lc + (c2 + j) * length + l2;
             T v = tile[threadIdx.x][threadIdx.y + j];
             if (bias != nullptr) v += bias[c2 + j];
+            // Residual first, then the activation: the seanet resnet block adds
+            // its skip connection to the conv output and any activation that
+            // follows consumes the sum.
+            if (residual != nullptr) v += residual[dst_idx];
             if (snake_alpha != nullptr)
                 v = snake_apply<T>(v, snake_alpha, snake_beta, c2 + j);
-            dst[b * lc + (c2 + j) * length + l2] = v;
+            dst[dst_idx] = v;
         }
     }
 }
@@ -431,7 +437,7 @@ extern "C" __global__ void transpose_blc_bcl_##RUST_NAME( \
     const TYPENAME *src, \
     TYPENAME *dst \
 ) { \
-    transpose_blc_to_bcl<TYPENAME>(length, channels, src, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, dst); \
+    transpose_blc_to_bcl<TYPENAME>(length, channels, src, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, dst); \
 } \
 extern "C" __global__ void transpose_blc_bcl_bias_##RUST_NAME( \
     const size_t length, \
@@ -440,20 +446,27 @@ extern "C" __global__ void transpose_blc_bcl_bias_##RUST_NAME( \
     const TYPENAME *bias, \
     TYPENAME *dst \
 ) { \
-    transpose_blc_to_bcl<TYPENAME>(length, channels, src, bias, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, dst); \
+    transpose_blc_to_bcl<TYPENAME>(length, channels, src, bias, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, dst); \
 }
 
-#define TRANSPOSE_BLC_BCL_BIAS_SNAKE_OP(TYPENAME, RUST_NAME) \
-extern "C" __global__ void transpose_blc_bcl_bias_snake_##RUST_NAME( \
+#define TRANSPOSE_BLC_BCL_FUSED_OP(TYPENAME, RUST_NAME) \
+extern "C" __global__ void transpose_blc_bcl_fused_##RUST_NAME( \
     const size_t length, \
     const size_t channels, \
+    const size_t flags, /* bit 0: apply snake, bit 1: add residual */ \
     const TYPENAME *src, \
     const TYPENAME *bias, \
     const TYPENAME *snake_alpha, \
     const TYPENAME *snake_beta, \
+    const TYPENAME *residual, \
     TYPENAME *dst \
 ) { \
-    transpose_blc_to_bcl<TYPENAME>(length, channels, src, bias, snake_alpha, snake_beta, dst); \
+    transpose_blc_to_bcl<TYPENAME>( \
+        length, channels, src, bias, \
+        (flags & 1) ? snake_alpha : (const TYPENAME*)nullptr, \
+        (flags & 1) ? snake_beta : (const TYPENAME*)nullptr, \
+        (flags & 2) ? residual : (const TYPENAME*)nullptr, \
+        dst); \
 }
 
 #define TRANSPOSE_BCL_BLC_OP(TYPENAME, RUST_NAME) \
@@ -472,7 +485,7 @@ extern "C" __global__ void transpose_bcl_blc_##RUST_NAME( \
     CONV1D_DIRECT_OP(TYPENAME, RUST_NAME) \
     CONV_TRANSPOSE1D_DIRECT_OP(TYPENAME, RUST_NAME) \
     TRANSPOSE_BLC_BCL_OP(TYPENAME, RUST_NAME) \
-    TRANSPOSE_BLC_BCL_BIAS_SNAKE_OP(TYPENAME, RUST_NAME) \
+    TRANSPOSE_BLC_BCL_FUSED_OP(TYPENAME, RUST_NAME) \
     TRANSPOSE_BCL_BLC_OP(TYPENAME, RUST_NAME)
 
 // ============================================================================

--- a/xn-core/cuda-kernels/conv.cu
+++ b/xn-core/cuda-kernels/conv.cu
@@ -243,12 +243,30 @@ __device__ void conv_transpose1d_direct_kernel(
 // Grid: (ceil(C/TILE), ceil(L/TILE), B), Block: (TILE, BLOCK_ROWS)
 // ============================================================================
 
+// Snake activation applied per output channel inside a conv epilogue:
+//   y = x + beta_scale[c] * sin(alpha[c] * x)^2
+// The epilogue already has the value in a register and owns the only write to
+// dst, so folding the activation in here removes a whole read+write pass.
+template <typename T>
+__device__ __forceinline__ T snake_apply(
+    T v,
+    const T *alpha,
+    const T *beta_scale,
+    const size_t c
+) {
+    const float x = to_float(v);
+    const float s = sinf(to_float(alpha[c]) * x);
+    return from_float<T>(x + to_float(beta_scale[c]) * s * s);
+}
+
 template <typename T, int TILE_DIM = 32, int BLOCK_ROWS = 8>
 __device__ void transpose_blc_to_bcl(
     const size_t length,
     const size_t channels,
     const T *src,
     const T *bias, // per-channel bias fused into the epilogue, may be nullptr
+    const T *snake_alpha,     // fused snake activation, may be nullptr
+    const T *snake_beta,
     T *dst
 ) {
     __shared__ T tile[TILE_DIM][TILE_DIM + 1];
@@ -275,6 +293,8 @@ __device__ void transpose_blc_to_bcl(
         if (l2 < (int)length && (c2 + j) < (int)channels) {
             T v = tile[threadIdx.x][threadIdx.y + j];
             if (bias != nullptr) v += bias[c2 + j];
+            if (snake_alpha != nullptr)
+                v = snake_apply<T>(v, snake_alpha, snake_beta, c2 + j);
             dst[b * lc + (c2 + j) * length + l2] = v;
         }
     }
@@ -411,7 +431,7 @@ extern "C" __global__ void transpose_blc_bcl_##RUST_NAME( \
     const TYPENAME *src, \
     TYPENAME *dst \
 ) { \
-    transpose_blc_to_bcl<TYPENAME>(length, channels, src, (const TYPENAME*)nullptr, dst); \
+    transpose_blc_to_bcl<TYPENAME>(length, channels, src, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, dst); \
 } \
 extern "C" __global__ void transpose_blc_bcl_bias_##RUST_NAME( \
     const size_t length, \
@@ -420,7 +440,20 @@ extern "C" __global__ void transpose_blc_bcl_bias_##RUST_NAME( \
     const TYPENAME *bias, \
     TYPENAME *dst \
 ) { \
-    transpose_blc_to_bcl<TYPENAME>(length, channels, src, bias, dst); \
+    transpose_blc_to_bcl<TYPENAME>(length, channels, src, bias, (const TYPENAME*)nullptr, (const TYPENAME*)nullptr, dst); \
+}
+
+#define TRANSPOSE_BLC_BCL_BIAS_SNAKE_OP(TYPENAME, RUST_NAME) \
+extern "C" __global__ void transpose_blc_bcl_bias_snake_##RUST_NAME( \
+    const size_t length, \
+    const size_t channels, \
+    const TYPENAME *src, \
+    const TYPENAME *bias, \
+    const TYPENAME *snake_alpha, \
+    const TYPENAME *snake_beta, \
+    TYPENAME *dst \
+) { \
+    transpose_blc_to_bcl<TYPENAME>(length, channels, src, bias, snake_alpha, snake_beta, dst); \
 }
 
 #define TRANSPOSE_BCL_BLC_OP(TYPENAME, RUST_NAME) \
@@ -439,6 +472,7 @@ extern "C" __global__ void transpose_bcl_blc_##RUST_NAME( \
     CONV1D_DIRECT_OP(TYPENAME, RUST_NAME) \
     CONV_TRANSPOSE1D_DIRECT_OP(TYPENAME, RUST_NAME) \
     TRANSPOSE_BLC_BCL_OP(TYPENAME, RUST_NAME) \
+    TRANSPOSE_BLC_BCL_BIAS_SNAKE_OP(TYPENAME, RUST_NAME) \
     TRANSPOSE_BCL_BLC_OP(TYPENAME, RUST_NAME)
 
 // ============================================================================

--- a/xn-core/cuda-kernels/conv.cu
+++ b/xn-core/cuda-kernels/conv.cu
@@ -81,6 +81,7 @@ __device__ void col2im1d_kernel(
     const size_t k_size,
     const size_t stride,
     const T *src,
+    const T *bias, // per-channel bias fused into the epilogue, may be nullptr
     T *dst
 ) {
     const size_t b = blockIdx.z;
@@ -112,7 +113,7 @@ __device__ void col2im1d_kernel(
             }
 
             size_t dst_idx = b * c_out * l_out + (size_t)c_idx * l_out + (size_t)l_out_idx;
-            dst[dst_idx] = sum;
+            dst[dst_idx] = (bias == nullptr) ? sum : sum + bias[c_idx];
         }
     }
 }
@@ -247,6 +248,7 @@ __device__ void transpose_blc_to_bcl(
     const size_t length,
     const size_t channels,
     const T *src,
+    const T *bias, // per-channel bias fused into the epilogue, may be nullptr
     T *dst
 ) {
     __shared__ T tile[TILE_DIM][TILE_DIM + 1];
@@ -270,8 +272,11 @@ __device__ void transpose_blc_to_bcl(
     int c2 = blockIdx.x * TILE_DIM + threadIdx.y;
 
     for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
-        if (l2 < (int)length && (c2 + j) < (int)channels)
-            dst[b * lc + (c2 + j) * length + l2] = tile[threadIdx.x][threadIdx.y + j];
+        if (l2 < (int)length && (c2 + j) < (int)channels) {
+            T v = tile[threadIdx.x][threadIdx.y + j];
+            if (bias != nullptr) v += bias[c2 + j];
+            dst[b * lc + (c2 + j) * length + l2] = v;
+        }
     }
 }
 
@@ -343,7 +348,19 @@ extern "C" __global__ void col2im1d_##RUST_NAME( \
     const TYPENAME *src, \
     TYPENAME *dst \
 ) { \
-    col2im1d_kernel<TYPENAME>(l_in, c_out, l_out, k_size, stride, src, dst); \
+    col2im1d_kernel<TYPENAME>(l_in, c_out, l_out, k_size, stride, src, (const TYPENAME*)nullptr, dst); \
+} \
+extern "C" __global__ void col2im1d_bias_##RUST_NAME( \
+    const size_t l_in, \
+    const size_t c_out, \
+    const size_t l_out, \
+    const size_t k_size, \
+    const size_t stride, \
+    const TYPENAME *src, \
+    const TYPENAME *bias, \
+    TYPENAME *dst \
+) { \
+    col2im1d_kernel<TYPENAME>(l_in, c_out, l_out, k_size, stride, src, bias, dst); \
 }
 
 #define CONV1D_DIRECT_OP(TYPENAME, RUST_NAME) \
@@ -394,7 +411,16 @@ extern "C" __global__ void transpose_blc_bcl_##RUST_NAME( \
     const TYPENAME *src, \
     TYPENAME *dst \
 ) { \
-    transpose_blc_to_bcl<TYPENAME>(length, channels, src, dst); \
+    transpose_blc_to_bcl<TYPENAME>(length, channels, src, (const TYPENAME*)nullptr, dst); \
+} \
+extern "C" __global__ void transpose_blc_bcl_bias_##RUST_NAME( \
+    const size_t length, \
+    const size_t channels, \
+    const TYPENAME *src, \
+    const TYPENAME *bias, \
+    TYPENAME *dst \
+) { \
+    transpose_blc_to_bcl<TYPENAME>(length, channels, src, bias, dst); \
 }
 
 #define TRANSPOSE_BCL_BLC_OP(TYPENAME, RUST_NAME) \

--- a/xn-core/src/backend.rs
+++ b/xn-core/src/backend.rs
@@ -184,6 +184,19 @@ pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
         eps: f32,
     ) -> Result<()>;
 
+    /// Fused snake activation: dst = x + beta_scale[c] * sin(alpha[c] * x)^2
+    /// src/dst are contiguous with `row_len` elements per channel row and
+    /// `channels` channels; alpha and beta_scale hold one value per channel.
+    fn snake<T: crate::WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        alpha: &Self::Storage<T>,
+        beta_scale: &Self::Storage<T>,
+        channels: usize,
+        row_len: usize,
+        numel: usize,
+    ) -> Result<()>;
+
     /// Layer normalization.
     /// Normalizes over the last dimension using mean and variance.
     /// When `remove_mean` is true: y = (x - mean) / sqrt(variance + eps) * weight + bias

--- a/xn-core/src/backend.rs
+++ b/xn-core/src/backend.rs
@@ -1,4 +1,13 @@
 use crate::Result;
+
+/// What a backend managed to fold into a convolution epilogue, see
+/// [`Backend::conv1d_fused`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ConvFused {
+    pub bias: bool,
+    pub snake: bool,
+    pub residual: bool,
+}
 use crate::{BinaryOp, UnaryOp};
 
 pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
@@ -405,17 +414,18 @@ pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
 
     /// Same as [`Backend::conv1d_with_bias`], additionally folding a
     /// per-channel snake activation (`y = x + beta[c] * sin(alpha[c] * x)^2`)
-    /// into the epilogue. Returns `(bias_applied, snake_applied)`; whatever the
-    /// backend did not apply, the caller must do separately. The default
-    /// implementation fuses neither the snake nor anything `conv1d_with_bias`
-    /// would not already fuse.
+    /// and/or a residual add into the epilogue. The residual is added before the
+    /// activation, matching a resnet block whose skip connection feeds the next
+    /// activation. Returns what was actually fused; whatever the backend did not
+    /// apply, the caller must do separately.
     #[allow(clippy::too_many_arguments)]
-    fn conv1d_with_bias_snake<T: crate::WithDTypeF>(
+    fn conv1d_fused<T: crate::WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,
         kernel: &Self::Storage<T>,
         bias: Option<&Self::Storage<T>>,
         _snake: Option<(&Self::Storage<T>, &Self::Storage<T>)>,
+        _residual: Option<&Self::Storage<T>>,
         batch: usize,
         in_channels: usize,
         out_channels: usize,
@@ -426,7 +436,7 @@ pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
         padding: usize,
         dilation: usize,
         groups: usize,
-    ) -> Result<(bool, bool)> {
+    ) -> Result<ConvFused> {
         let bias_applied = Self::conv1d_with_bias(
             dst,
             src,
@@ -443,7 +453,7 @@ pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
             dilation,
             groups,
         )?;
-        Ok((bias_applied, false))
+        Ok(ConvFused { bias: bias_applied, snake: false, residual: false })
     }
 
     /// Same as [`Backend::conv_transpose1d`], with the bias-fusion contract

--- a/xn-core/src/backend.rs
+++ b/xn-core/src/backend.rs
@@ -382,6 +382,49 @@ pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
         Ok(false)
     }
 
+    /// Same as [`Backend::conv1d_with_bias`], additionally folding a
+    /// per-channel snake activation (`y = x + beta[c] * sin(alpha[c] * x)^2`)
+    /// into the epilogue. Returns `(bias_applied, snake_applied)`; whatever the
+    /// backend did not apply, the caller must do separately. The default
+    /// implementation fuses neither the snake nor anything `conv1d_with_bias`
+    /// would not already fuse.
+    #[allow(clippy::too_many_arguments)]
+    fn conv1d_with_bias_snake<T: crate::WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        bias: Option<&Self::Storage<T>>,
+        _snake: Option<(&Self::Storage<T>, &Self::Storage<T>)>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<(bool, bool)> {
+        let bias_applied = Self::conv1d_with_bias(
+            dst,
+            src,
+            kernel,
+            bias,
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+        )?;
+        Ok((bias_applied, false))
+    }
+
     /// Same as [`Backend::conv_transpose1d`], with the bias-fusion contract
     /// of [`Backend::conv1d_with_bias`].
     #[allow(clippy::too_many_arguments)]

--- a/xn-core/src/backend.rs
+++ b/xn-core/src/backend.rs
@@ -197,6 +197,27 @@ pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
         numel: usize,
     ) -> Result<()>;
 
+    /// Snake activation writing into a window of a longer destination:
+    /// `dst[b, c, dst_offset + l] = snake(src[b, c, l])`, where `dst` rows are
+    /// `dst_len` long and `src` rows `src_len`. Lets the streaming-conv input
+    /// concatenation absorb the activation instead of paying a separate pass.
+    /// Backends that do not implement it must be driven through
+    /// [`Backend::snake`] plus a copy by the caller.
+    #[allow(clippy::too_many_arguments)]
+    fn snake_offset<T: crate::WithDTypeF>(
+        _dst: &mut Self::Storage<T>,
+        _src: &Self::Storage<T>,
+        _alpha: &Self::Storage<T>,
+        _beta_scale: &Self::Storage<T>,
+        _channels: usize,
+        _src_len: usize,
+        _dst_len: usize,
+        _dst_offset: usize,
+        _numel: usize,
+    ) -> Result<()> {
+        crate::bail!("snake_offset is not implemented for this backend")
+    }
+
     /// Layer normalization.
     /// Normalizes over the last dimension using mean and variance.
     /// When `remove_mean` is true: y = (x - mean) / sqrt(variance + eps) * weight + bias

--- a/xn-core/src/backend.rs
+++ b/xn-core/src/backend.rs
@@ -342,4 +342,80 @@ pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
         output_padding: usize,
         groups: usize,
     ) -> Result<()>;
+
+    /// Same as [`Backend::conv1d`], but backends that can fuse the
+    /// per-channel bias into the convolution epilogue apply it and return
+    /// `Ok(true)`. The default implementation ignores the bias and returns
+    /// `Ok(false)`, in which case the caller must apply it separately.
+    #[allow(clippy::too_many_arguments)]
+    fn conv1d_with_bias<T: crate::WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        _bias: Option<&Self::Storage<T>>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        Self::conv1d(
+            dst,
+            src,
+            kernel,
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+        )?;
+        Ok(false)
+    }
+
+    /// Same as [`Backend::conv_transpose1d`], with the bias-fusion contract
+    /// of [`Backend::conv1d_with_bias`].
+    #[allow(clippy::too_many_arguments)]
+    fn conv_transpose1d_with_bias<T: crate::WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        _bias: Option<&Self::Storage<T>>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        output_padding: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        Self::conv_transpose1d(
+            dst,
+            src,
+            kernel,
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            output_padding,
+            groups,
+        )?;
+        Ok(false)
+    }
 }

--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -958,6 +958,32 @@ impl crate::Backend for crate::CpuDevice {
         Ok(())
     }
 
+    fn snake<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        alpha: &Self::Storage<T>,
+        beta_scale: &Self::Storage<T>,
+        channels: usize,
+        row_len: usize,
+        numel: usize,
+    ) -> Result<()> {
+        let src = &src[..numel];
+        let dst = &mut dst[..numel];
+        src.par_chunks(row_len).zip(dst.par_chunks_mut(row_len)).enumerate().for_each(
+            |(row, (src, dst))| {
+                let c = row % channels;
+                let alpha = alpha[c].to_f32();
+                let beta_scale = beta_scale[c].to_f32();
+                for (d, s) in dst.iter_mut().zip(src.iter()) {
+                    let x = (*s).to_f32();
+                    let sin = (alpha * x).sin();
+                    *d = T::from_f32(x + beta_scale * sin * sin)
+                }
+            },
+        );
+        Ok(())
+    }
+
     fn layer_norm<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/src/cuda_backend/cudnn_conv.rs
+++ b/xn-core/src/cuda_backend/cudnn_conv.rs
@@ -1,0 +1,213 @@
+//! Optional cuDNN path for f32 conv1d / conv_transpose1d, enabled with
+//! XN_CUDNN=1. 1D convolutions run as 4D NCHW convolutions with H=1, which
+//! writes the output directly in (b, c, l) layout — no im2col buffer and no
+//! transpose. conv1d fuses the per-channel bias via
+//! cudnnConvolutionBiasActivationForward with an identity activation;
+//! conv_transpose1d maps to cudnnConvolutionBackwardData (bias not fused).
+use super::{Device, Storage};
+use crate::Result;
+use cudarc::cudnn::{Cudnn, sys};
+use cudarc::driver::CudaSlice;
+use std::sync::{Arc, Mutex};
+
+pub(crate) fn enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("XN_CUDNN").is_ok_and(|v| v == "1"))
+}
+
+fn tf32() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("XN_TF32").is_ok_and(|v| v == "1"))
+}
+
+/// Lazily-created cuDNN handle. `Cudnn` is not Send/Sync because cuDNN
+/// handles require externally serialized access; the mutex is held for the
+/// whole descriptor-setup + launch sequence, which provides that
+/// serialization.
+pub(crate) struct CudnnCtx(Mutex<Option<Arc<Cudnn>>>);
+unsafe impl Send for CudnnCtx {}
+unsafe impl Sync for CudnnCtx {}
+
+impl CudnnCtx {
+    pub(crate) fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+}
+
+fn with_cudnn<R>(device: &Device, f: impl FnOnce(&Arc<Cudnn>) -> Result<R>) -> Result<R> {
+    let mut guard = device.cudnn.0.lock().unwrap();
+    if guard.is_none() {
+        *guard = Some(Cudnn::new(device.stream().clone())?);
+    }
+    f(guard.as_ref().unwrap())
+}
+
+fn math_type() -> sys::cudnnMathType_t {
+    if tf32() {
+        sys::cudnnMathType_t::CUDNN_TENSOR_OP_MATH
+    } else {
+        sys::cudnnMathType_t::CUDNN_DEFAULT_MATH
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn conv1d_f32(
+    dst: &mut Storage<f32>,
+    src: &Storage<f32>,
+    kernel: &Storage<f32>,
+    bias: Option<&CudaSlice<f32>>,
+    batch: usize,
+    in_channels: usize,
+    out_channels: usize,
+    length: usize,
+    out_length: usize,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+) -> Result<()> {
+    let device = dst.device.clone();
+    with_cudnn(&device, |cudnn| {
+        const NCHW: sys::cudnnTensorFormat_t = sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW;
+        let x_desc = cudnn
+            .create_4d_tensor::<f32>(NCHW, [batch as i32, in_channels as i32, 1, length as i32])?;
+        let w_desc = cudnn.create_4d_filter::<f32>(
+            NCHW,
+            [out_channels as i32, in_channels as i32, 1, kernel_size as i32],
+        )?;
+        let y_desc = cudnn.create_4d_tensor::<f32>(
+            NCHW,
+            [batch as i32, out_channels as i32, 1, out_length as i32],
+        )?;
+        let mut conv = cudnn.create_conv2d::<f32>(
+            [0, padding as i32],
+            [1, stride as i32],
+            [1, dilation as i32],
+            sys::cudnnConvolutionMode_t::CUDNN_CROSS_CORRELATION,
+        )?;
+        conv.set_math_type(math_type())?;
+
+        match bias {
+            Some(bias) => {
+                let bias_desc =
+                    cudnn.create_4d_tensor::<f32>(NCHW, [1, out_channels as i32, 1, 1])?;
+                let act = cudnn.create_activation::<f32>(
+                    sys::cudnnActivationMode_t::CUDNN_ACTIVATION_IDENTITY,
+                    sys::cudnnNanPropagation_t::CUDNN_NOT_PROPAGATE_NAN,
+                    0.0,
+                )?;
+                let op = cudarc::cudnn::ConvBiasActivationForward::<f32, f32, f32, f32> {
+                    conv: &conv,
+                    act: &act,
+                    x: &x_desc,
+                    w: &w_desc,
+                    z: &y_desc,
+                    bias: &bias_desc,
+                    y: &y_desc,
+                };
+                // The identity activation only supports this algorithm.
+                let algo = sys::cudnnConvolutionFwdAlgo_t::CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM;
+                let ws_size = op.get_workspace_size(algo)?;
+                let mut workspace: CudaSlice<u8> =
+                    unsafe { device.stream().alloc(ws_size.max(1)) }?;
+                // alpha2 = 0 so the z tensor is never dereferenced; src stands
+                // in as a valid device pointer of the right dtype.
+                unsafe {
+                    op.launch(
+                        algo,
+                        Some(&mut workspace),
+                        (1.0f32, 0.0f32),
+                        &*src.data,
+                        &*kernel.data,
+                        &*src.data,
+                        bias,
+                        &mut *dst.data,
+                    )
+                }?;
+            }
+            None => {
+                let op = cudarc::cudnn::ConvForward::<f32, f32, f32> {
+                    conv: &conv,
+                    x: &x_desc,
+                    w: &w_desc,
+                    y: &y_desc,
+                };
+                let algo = op.pick_algorithm()?;
+                let ws_size = op.get_workspace_size(algo)?;
+                let mut workspace: CudaSlice<u8> =
+                    unsafe { device.stream().alloc(ws_size.max(1)) }?;
+                unsafe {
+                    op.launch(
+                        algo,
+                        Some(&mut workspace),
+                        (1.0f32, 0.0f32),
+                        &*src.data,
+                        &*kernel.data,
+                        &mut *dst.data,
+                    )
+                }?;
+            }
+        }
+        Ok(())
+    })
+}
+
+/// Transposed convolution as the data-gradient of the equivalent forward
+/// convolution. The xn kernel layout (in_channels, out_channels, k) is
+/// exactly cuDNN's filter layout for that virtual forward conv.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn conv_transpose1d_f32(
+    dst: &mut Storage<f32>,
+    src: &Storage<f32>,
+    kernel: &Storage<f32>,
+    batch: usize,
+    in_channels: usize,
+    out_channels: usize,
+    length: usize,
+    out_length: usize,
+    kernel_size: usize,
+    stride: usize,
+) -> Result<()> {
+    let device = dst.device.clone();
+    with_cudnn(&device, |cudnn| {
+        const NCHW: sys::cudnnTensorFormat_t = sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW;
+        let dy_desc = cudnn
+            .create_4d_tensor::<f32>(NCHW, [batch as i32, in_channels as i32, 1, length as i32])?;
+        let w_desc = cudnn.create_4d_filter::<f32>(
+            NCHW,
+            [in_channels as i32, out_channels as i32, 1, kernel_size as i32],
+        )?;
+        let dx_desc = cudnn.create_4d_tensor::<f32>(
+            NCHW,
+            [batch as i32, out_channels as i32, 1, out_length as i32],
+        )?;
+        let mut conv = cudnn.create_conv2d::<f32>(
+            [0, 0],
+            [1, stride as i32],
+            [1, 1],
+            sys::cudnnConvolutionMode_t::CUDNN_CROSS_CORRELATION,
+        )?;
+        conv.set_math_type(math_type())?;
+
+        let op = cudarc::cudnn::ConvBackwardData::<f32, f32, f32> {
+            conv: &conv,
+            dx: &dx_desc,
+            w: &w_desc,
+            dy: &dy_desc,
+        };
+        let algo = op.pick_algorithm()?;
+        let ws_size = op.get_workspace_size(algo)?;
+        let mut workspace: CudaSlice<u8> = unsafe { device.stream().alloc(ws_size.max(1)) }?;
+        unsafe {
+            op.launch(
+                algo,
+                Some(&mut workspace),
+                (1.0f32, 0.0f32),
+                &mut *dst.data,
+                &*kernel.data,
+                &*src.data,
+            )
+        }?;
+        Ok(())
+    })
+}

--- a/xn-core/src/cuda_backend/cudnn_conv.rs
+++ b/xn-core/src/cuda_backend/cudnn_conv.rs
@@ -153,6 +153,24 @@ fn nofuse_bias() -> bool {
     *ON.get_or_init(|| std::env::var("XN_CUDNN_NOFUSE").is_ok_and(|v| v == "1"))
 }
 
+/// XN_CUDNN_FWD_ONLY=1 keeps conv_transpose1d on xn's col2im path. cuDNN
+/// reaches the transposed convolution through ConvolutionBackwardData, whose
+/// legacy-API engines are far slower here than col2im+gemm.
+pub(crate) fn fwd_only() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("XN_CUDNN_FWD_ONLY").is_ok_and(|v| v == "1"))
+}
+
+/// XN_CUDNN_MIN_K: smallest kernel size routed to cuDNN (default 1, i.e. all).
+/// Kernel-size-1 convolutions gain little from implicit gemm — their im2col is a
+/// cheap transpose — and routing them to cuDNN forfeits the fused epilogue.
+pub(crate) fn min_kernel_size() -> usize {
+    static K: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *K.get_or_init(|| {
+        std::env::var("XN_CUDNN_MIN_K").ok().and_then(|v| v.parse().ok()).unwrap_or(1)
+    })
+}
+
 fn math_type() -> sys::cudnnMathType_t {
     if tf32() {
         sys::cudnnMathType_t::CUDNN_TENSOR_OP_MATH

--- a/xn-core/src/cuda_backend/cudnn_conv.rs
+++ b/xn-core/src/cuda_backend/cudnn_conv.rs
@@ -42,6 +42,15 @@ fn with_cudnn<R>(device: &Device, f: impl FnOnce(&Arc<Cudnn>) -> Result<R>) -> R
     f(guard.as_ref().unwrap())
 }
 
+/// XN_CUDNN_NOFUSE=1: skip the fused bias epilogue so the forward conv can use
+/// the heuristically-picked algorithm instead of IMPLICIT_PRECOMP_GEMM, which
+/// is the only algorithm the identity activation supports. Bias is then added
+/// by the caller. Experiment gate: fusing bias costs the tensor-core path.
+fn nofuse_bias() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("XN_CUDNN_NOFUSE").is_ok_and(|v| v == "1"))
+}
+
 fn math_type() -> sys::cudnnMathType_t {
     if tf32() {
         sys::cudnnMathType_t::CUDNN_TENSOR_OP_MATH
@@ -65,7 +74,7 @@ pub(crate) fn conv1d_f32(
     stride: usize,
     padding: usize,
     dilation: usize,
-) -> Result<()> {
+) -> Result<bool> {
     let device = dst.device.clone();
     with_cudnn(&device, |cudnn| {
         const NCHW: sys::cudnnTensorFormat_t = sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW;
@@ -87,7 +96,7 @@ pub(crate) fn conv1d_f32(
         )?;
         conv.set_math_type(math_type())?;
 
-        match bias {
+        match bias.filter(|_| !nofuse_bias()) {
             Some(bias) => {
                 let bias_desc =
                     cudnn.create_4d_tensor::<f32>(NCHW, [1, out_channels as i32, 1, 1])?;
@@ -124,6 +133,7 @@ pub(crate) fn conv1d_f32(
                         &mut *dst.data,
                     )
                 }?;
+                return Ok(true);
             }
             None => {
                 let op = cudarc::cudnn::ConvForward::<f32, f32, f32> {
@@ -148,7 +158,7 @@ pub(crate) fn conv1d_f32(
                 }?;
             }
         }
-        Ok(())
+        Ok(false)
     })
 }
 

--- a/xn-core/src/cuda_backend/cudnn_conv.rs
+++ b/xn-core/src/cuda_backend/cudnn_conv.rs
@@ -20,26 +20,128 @@ fn tf32() -> bool {
     *ON.get_or_init(|| std::env::var("XN_TF32").is_ok_and(|v| v == "1"))
 }
 
-/// Lazily-created cuDNN handle. `Cudnn` is not Send/Sync because cuDNN
-/// handles require externally serialized access; the mutex is held for the
-/// whole descriptor-setup + launch sequence, which provides that
-/// serialization.
-pub(crate) struct CudnnCtx(Mutex<Option<Arc<Cudnn>>>);
+/// XN_CUDNN_AUTOTUNE=0 disables the measured algorithm search and falls back to
+/// the cuDNN v7 heuristic. Autotuning is what XLA does: its dumped conv configs
+/// carry per-shape engine ids and tuning knobs picked by measurement, not by
+/// `cudnnGetConvolutionForwardAlgorithm_v7`.
+fn autotune() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| !std::env::var("XN_CUDNN_AUTOTUNE").is_ok_and(|v| v == "0"))
+}
+
+/// Identifies a conv shape for the algorithm cache. Two calls with the same key
+/// run the same cuDNN problem, so the measured winner carries over.
+#[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
+struct ConvKey {
+    batch: usize,
+    in_c: usize,
+    out_c: usize,
+    length: usize,
+    out_length: usize,
+    k: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+}
+
+/// Lazily-created cuDNN handle plus the per-shape algorithm caches. `Cudnn` is
+/// not Send/Sync because cuDNN handles require externally serialized access;
+/// the mutex is held for the whole descriptor-setup + launch sequence, which
+/// provides that serialization.
+pub(crate) struct CudnnCtx {
+    handle: Mutex<Option<Arc<Cudnn>>>,
+    fwd: Mutex<std::collections::HashMap<ConvKey, sys::cudnnConvolutionFwdAlgo_t>>,
+    bwd: Mutex<std::collections::HashMap<ConvKey, sys::cudnnConvolutionBwdDataAlgo_t>>,
+}
 unsafe impl Send for CudnnCtx {}
 unsafe impl Sync for CudnnCtx {}
 
 impl CudnnCtx {
     pub(crate) fn new() -> Self {
-        Self(Mutex::new(None))
+        Self {
+            handle: Mutex::new(None),
+            fwd: Mutex::new(Default::default()),
+            bwd: Mutex::new(Default::default()),
+        }
     }
 }
 
 fn with_cudnn<R>(device: &Device, f: impl FnOnce(&Arc<Cudnn>) -> Result<R>) -> Result<R> {
-    let mut guard = device.cudnn.0.lock().unwrap();
+    let mut guard = device.cudnn.handle.lock().unwrap();
     if guard.is_none() {
         *guard = Some(Cudnn::new(device.stream().clone())?);
     }
     f(guard.as_ref().unwrap())
+}
+
+/// Every forward algorithm cuDNN defines, as autotuning candidates. Ones that
+/// do not support the problem fail at the workspace query and are skipped.
+const FWD_ALGOS: [sys::cudnnConvolutionFwdAlgo_t; 8] = {
+    use sys::cudnnConvolutionFwdAlgo_t as A;
+    [
+        A::CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM,
+        A::CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM,
+        A::CUDNN_CONVOLUTION_FWD_ALGO_GEMM,
+        A::CUDNN_CONVOLUTION_FWD_ALGO_DIRECT,
+        A::CUDNN_CONVOLUTION_FWD_ALGO_FFT,
+        A::CUDNN_CONVOLUTION_FWD_ALGO_FFT_TILING,
+        A::CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD,
+        A::CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED,
+    ]
+};
+
+const BWD_ALGOS: [sys::cudnnConvolutionBwdDataAlgo_t; 6] = {
+    use sys::cudnnConvolutionBwdDataAlgo_t as A;
+    [
+        A::CUDNN_CONVOLUTION_BWD_DATA_ALGO_0,
+        A::CUDNN_CONVOLUTION_BWD_DATA_ALGO_1,
+        A::CUDNN_CONVOLUTION_BWD_DATA_ALGO_FFT,
+        A::CUDNN_CONVOLUTION_BWD_DATA_ALGO_FFT_TILING,
+        A::CUDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD,
+        A::CUDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD_NONFUSED,
+    ]
+};
+
+/// Time `run` for each candidate and return the fastest, mirroring XLA's
+/// autotuner: 2 warmup plus 5 timed reps per candidate, device-synchronized.
+/// Candidates that error (unsupported for this problem, or out of memory) are
+/// skipped; if every one fails the caller's fallback algorithm is returned.
+fn autotune_algo<A: Copy>(
+    device: &Device,
+    candidates: &[A],
+    fallback: A,
+    mut run: impl FnMut(A) -> Result<()>,
+) -> A {
+    let mut best = (f64::INFINITY, fallback);
+    for &algo in candidates {
+        if run(algo).is_err() {
+            continue;
+        }
+        for _ in 0..2 {
+            if run(algo).is_err() {
+                continue;
+            }
+        }
+        if device.stream().synchronize().is_err() {
+            continue;
+        }
+        let t0 = std::time::Instant::now();
+        let mut ok = true;
+        for _ in 0..5 {
+            if run(algo).is_err() {
+                ok = false;
+                break;
+            }
+        }
+        if !ok || device.stream().synchronize().is_err() {
+            continue;
+        }
+        let elapsed = t0.elapsed().as_secs_f64();
+        if elapsed < best.0 {
+            best = (elapsed, algo);
+        }
+    }
+    best.1
 }
 
 /// XN_CUDNN_NOFUSE=1: skip the fused bias epilogue so the forward conv can use
@@ -142,7 +244,46 @@ pub(crate) fn conv1d_f32(
                     w: &w_desc,
                     y: &y_desc,
                 };
-                let algo = op.pick_algorithm()?;
+                let key = ConvKey {
+                    batch,
+                    in_c: in_channels,
+                    out_c: out_channels,
+                    length,
+                    out_length,
+                    k: kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                };
+                let cached = device.cudnn.fwd.lock().unwrap().get(&key).copied();
+                let algo = match cached {
+                    Some(algo) => algo,
+                    None => {
+                        let heuristic = op.pick_algorithm()?;
+                        let algo = if autotune() {
+                            autotune_algo(&device, &FWD_ALGOS, heuristic, |algo| {
+                                let ws = op.get_workspace_size(algo)?;
+                                let mut workspace: CudaSlice<u8> =
+                                    unsafe { device.stream().alloc(ws.max(1)) }?;
+                                unsafe {
+                                    op.launch(
+                                        algo,
+                                        Some(&mut workspace),
+                                        (1.0f32, 0.0f32),
+                                        &*src.data,
+                                        &*kernel.data,
+                                        &mut *dst.data,
+                                    )
+                                }?;
+                                Ok(())
+                            })
+                        } else {
+                            heuristic
+                        };
+                        device.cudnn.fwd.lock().unwrap().insert(key, algo);
+                        algo
+                    }
+                };
                 let ws_size = op.get_workspace_size(algo)?;
                 let mut workspace: CudaSlice<u8> =
                     unsafe { device.stream().alloc(ws_size.max(1)) }?;
@@ -205,7 +346,46 @@ pub(crate) fn conv_transpose1d_f32(
             w: &w_desc,
             dy: &dy_desc,
         };
-        let algo = op.pick_algorithm()?;
+        let key = ConvKey {
+            batch,
+            in_c: in_channels,
+            out_c: out_channels,
+            length,
+            out_length,
+            k: kernel_size,
+            stride,
+            padding: 0,
+            dilation: 1,
+        };
+        let cached = device.cudnn.bwd.lock().unwrap().get(&key).copied();
+        let algo = match cached {
+            Some(algo) => algo,
+            None => {
+                let heuristic = op.pick_algorithm()?;
+                let algo = if autotune() {
+                    autotune_algo(&device, &BWD_ALGOS, heuristic, |algo| {
+                        let ws = op.get_workspace_size(algo)?;
+                        let mut workspace: CudaSlice<u8> =
+                            unsafe { device.stream().alloc(ws.max(1)) }?;
+                        unsafe {
+                            op.launch(
+                                algo,
+                                Some(&mut workspace),
+                                (1.0f32, 0.0f32),
+                                &mut *dst.data,
+                                &*kernel.data,
+                                &*src.data,
+                            )
+                        }?;
+                        Ok(())
+                    })
+                } else {
+                    heuristic
+                };
+                device.cudnn.bwd.lock().unwrap().insert(key, algo);
+                algo
+            }
+        };
         let ws_size = op.get_workspace_size(algo)?;
         let mut workspace: CudaSlice<u8> = unsafe { device.stream().alloc(ws_size.max(1)) }?;
         unsafe {

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -1511,6 +1511,34 @@ impl crate::Backend for Device {
         Ok(())
     }
 
+    fn snake_offset<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        alpha: &Self::Storage<T>,
+        beta_scale: &Self::Storage<T>,
+        channels: usize,
+        src_len: usize,
+        dst_len: usize,
+        dst_offset: usize,
+        numel: usize,
+    ) -> Result<()> {
+        let kname = kernel_name::<T>("snake_offset");
+        let func = dst.device.get_func(&kname, PTXModule::Broadcast)?;
+        let cfg = LaunchConfig::for_num_elems(numel as u32);
+        let mut launch_args = dst.device.stream.launch_builder(&func);
+        launch_args.arg(&numel);
+        launch_args.arg(&channels);
+        launch_args.arg(&src_len);
+        launch_args.arg(&dst_len);
+        launch_args.arg(&dst_offset);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&*alpha.data);
+        launch_args.arg(&*beta_scale.data);
+        launch_args.arg(&mut *dst.data);
+        unsafe { launch_args.launch(cfg) }?;
+        Ok(())
+    }
+
     fn snake<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 mod cublaslt;
+mod cudnn_conv;
 mod kernels;
 pub mod quantization;
 
@@ -59,6 +60,8 @@ pub struct DeviceInner {
     stream: Arc<CudaStream>,
     blas: cudarc::cublas::CudaBlas,
     pub(crate) blas_lt: cublaslt::CudaBlasLT,
+    /// Lazily-initialized cuDNN handle used by the XN_CUDNN=1 conv path.
+    cudnn: cudnn_conv::CudnnCtx,
     curand: Mutex<CudaRng>,
     /// Cache for loaded PTX modules
     modules: Mutex<ModuleCache>,
@@ -158,6 +161,7 @@ impl Device {
             stream,
             blas,
             blas_lt,
+            cudnn: cudnn_conv::CudnnCtx::new(),
             modules: Mutex::new(Default::default()),
             curand: Mutex::new(CudaRng(curand)),
             htod_mode: std::sync::atomic::AtomicU8::new(0),
@@ -2038,6 +2042,29 @@ impl crate::Backend for Device {
         dilation: usize,
         groups: usize,
     ) -> Result<bool> {
+        if cudnn_conv::enabled() && groups == 1 && T::DTYPE == DType::F32 {
+            let dst = unsafe { &mut *(dst as *mut Storage<T> as *mut Storage<f32>) };
+            let src = unsafe { &*(src as *const Storage<T> as *const Storage<f32>) };
+            let kernel = unsafe { &*(kernel as *const Storage<T> as *const Storage<f32>) };
+            let bias = bias
+                .map(|b| unsafe { &*(&*b.data as *const CudaSlice<T> as *const CudaSlice<f32>) });
+            cudnn_conv::conv1d_f32(
+                dst,
+                src,
+                kernel,
+                bias,
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+            )?;
+            return Ok(bias.is_some());
+        }
         if groups == 1 {
             conv1d_im2col(
                 dst,
@@ -2091,6 +2118,31 @@ impl crate::Backend for Device {
         output_padding: usize,
         groups: usize,
     ) -> Result<bool> {
+        if cudnn_conv::enabled()
+            && groups == 1
+            && padding == 0
+            && output_padding == 0
+            && T::DTYPE == DType::F32
+        {
+            let dst = unsafe { &mut *(dst as *mut Storage<T> as *mut Storage<f32>) };
+            let src = unsafe { &*(src as *const Storage<T> as *const Storage<f32>) };
+            let kernel = unsafe { &*(kernel as *const Storage<T> as *const Storage<f32>) };
+            cudnn_conv::conv_transpose1d_f32(
+                dst,
+                src,
+                kernel,
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+            )?;
+            // The backward-data path has no fused bias epilogue; let the
+            // caller apply it.
+            return Ok(false);
+        }
         let can_use_col2im = groups == 1 && padding == 0 && output_padding == 0;
         if can_use_col2im {
             conv_transpose1d_col2im(

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -1940,6 +1940,7 @@ impl crate::Backend for Device {
                 src,
                 kernel,
                 None,
+                None,
                 batch,
                 in_channels,
                 out_channels,
@@ -2070,6 +2071,7 @@ impl crate::Backend for Device {
                 src,
                 kernel,
                 bias.map(|b| &*b.data),
+                None,
                 batch,
                 in_channels,
                 out_channels,
@@ -2098,6 +2100,69 @@ impl crate::Backend for Device {
                 groups,
             )?;
             Ok(false)
+        }
+    }
+
+    fn conv1d_with_bias_snake<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        bias: Option<&Self::Storage<T>>,
+        snake: Option<(&Self::Storage<T>, &Self::Storage<T>)>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<(bool, bool)> {
+        // Only the im2col path owns its store epilogue, so that is the only one
+        // that can fold the activation in. cuDNN and the direct kernel fall
+        // back to the plain contract.
+        let fusable = groups == 1 && !cudnn_conv::enabled();
+        match (snake, fusable) {
+            (Some((alpha, beta)), true) if bias.is_some() => {
+                conv1d_im2col(
+                    dst,
+                    src,
+                    kernel,
+                    bias.map(|b| &*b.data),
+                    Some((&alpha.data, &beta.data)),
+                    batch,
+                    in_channels,
+                    out_channels,
+                    length,
+                    out_length,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                )?;
+                Ok((true, true))
+            }
+            _ => {
+                let bias_applied = Self::conv1d_with_bias(
+                    dst,
+                    src,
+                    kernel,
+                    bias,
+                    batch,
+                    in_channels,
+                    out_channels,
+                    length,
+                    out_length,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    groups,
+                )?;
+                Ok((bias_applied, false))
+            }
         }
     }
 
@@ -2183,11 +2248,13 @@ impl crate::Backend for Device {
 // Conv1d implementation using im2col + cuBLAS gemm
 // ============================================================================
 
+#[allow(clippy::too_many_arguments)]
 fn conv1d_im2col<T: WithDTypeF>(
     dst: &mut Storage<T>,
     src: &Storage<T>,
     kernel: &Storage<T>,
     bias: Option<&CudaSlice<T>>,
+    snake: Option<(&CudaSlice<T>, &CudaSlice<T>)>,
     batch: usize,
     in_channels: usize,
     out_channels: usize,
@@ -2246,9 +2313,14 @@ fn conv1d_im2col<T: WithDTypeF>(
 
     // Step 3: Transpose from [B, L_out, out_channels] to [B, out_channels, L_out],
     // fusing the per-channel bias into the store when provided.
-    let kname = match bias {
-        Some(_) => format!("transpose_blc_bcl_bias_{}", T::DTYPE.cuda_name()),
-        None => format!("transpose_blc_bcl_{}", T::DTYPE.cuda_name()),
+    // The fused-snake epilogue is only wired for the bias case, which is what
+    // the seanet decoder always uses; a bias-less snake falls back to a
+    // separate activation pass (see `Tensor::conv1d_snake`).
+    let snake = snake.filter(|_| bias.is_some());
+    let kname = match (bias, snake) {
+        (Some(_), Some(_)) => format!("transpose_blc_bcl_bias_snake_{}", T::DTYPE.cuda_name()),
+        (Some(_), None) => format!("transpose_blc_bcl_bias_{}", T::DTYPE.cuda_name()),
+        (None, _) => format!("transpose_blc_bcl_{}", T::DTYPE.cuda_name()),
     };
     let func = dst.device.get_func(&kname, PTXModule::Conv)?;
     let cfg = LaunchConfig {
@@ -2265,8 +2337,25 @@ fn conv1d_im2col<T: WithDTypeF>(
     launch_args.arg(&out_length);
     launch_args.arg(&out_channels);
     launch_args.arg(&result);
-    if let Some(bias) = bias {
-        launch_args.arg(bias);
+    match snake {
+        None => {
+            if let Some(bias) = bias {
+                launch_args.arg(bias);
+            }
+        }
+        Some((alpha, beta)) => {
+            // `snake` was filtered to the bias case above, so bias is Some here.
+            let bias = match bias {
+                Some(bias) => bias,
+                None => crate::bail!("fused snake epilogue requires a bias"),
+            };
+            launch_args.arg(bias);
+            launch_args.arg(alpha);
+            launch_args.arg(beta);
+            launch_args.arg(&mut *dst.data);
+            unsafe { launch_args.launch(cfg) }?;
+            return Ok(());
+        }
     }
     launch_args.arg(&mut *dst.data);
     unsafe { launch_args.launch(cfg) }?;

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -228,6 +228,12 @@ impl Device {
         }
     }
 
+    /// Whether the device stream is currently being captured into a CUDA
+    /// graph (between [`Device::capture_begin`] and [`Device::capture_end`]).
+    pub fn is_capturing(&self) -> bool {
+        self.htod_mode.load(std::sync::atomic::Ordering::Relaxed) == htod_mode::REPLAY
+    }
+
     /// Start recording host uploads in the device-side cache, see
     /// [`Device::cached_htod`]. Run the exact workload to be captured once
     /// under record mode before capturing it with [`Device::capture_begin`];
@@ -438,8 +444,22 @@ impl Device {
 
 /// CUDA storage that holds both the device data and a reference to the device.
 pub struct Storage<T: WithDType> {
-    pub data: CudaSlice<T>,
+    pub data: std::mem::ManuallyDrop<CudaSlice<T>>,
     pub device: Device,
+}
+
+impl<T: WithDType> Drop for Storage<T> {
+    fn drop(&mut self) {
+        if self.device.is_capturing() {
+            // A stream-ordered free of memory allocated outside the capture
+            // is invalid while the stream is capturing a CUDA graph
+            // (CUDA_ERROR_INVALID_VALUE at capture time). Leak the buffer
+            // instead: captures are short one-step windows, so the leak is
+            // bounded by one step of state churn.
+        } else {
+            unsafe { std::mem::ManuallyDrop::drop(&mut self.data) }
+        }
+    }
 }
 
 impl<T: WithDType> Storage<T> {
@@ -587,7 +607,7 @@ fn gemm_f32(
 
     let lhs = lhs.0.data.slice(lhs.1..);
     let rhs = rhs.0.data.slice(rhs.1..);
-    unsafe { gemm_strided_batched_f32(&dst.device.blas, cfg, &rhs, &lhs, &mut dst.data)? }
+    unsafe { gemm_strided_batched_f32(&dst.device.blas, cfg, &rhs, &lhs, &mut *dst.data)? }
 
     Ok(())
 }
@@ -620,7 +640,7 @@ fn gemm_f16(
     )?;
     let lhs = lhs.0.data.slice(lhs.1..);
     let rhs = rhs.0.data.slice(rhs.1..);
-    unsafe { gemm_strided_batched_f16(&dst.device.blas, cfg, &rhs, &lhs, &mut dst.data)? }
+    unsafe { gemm_strided_batched_f16(&dst.device.blas, cfg, &rhs, &lhs, &mut *dst.data)? }
 
     Ok(())
 }
@@ -653,7 +673,7 @@ fn gemm_bf16(
     )?;
     let lhs = lhs.0.data.slice(lhs.1..);
     let rhs = rhs.0.data.slice(rhs.1..);
-    unsafe { gemm_strided_batched_bf16(&dst.device.blas, cfg, &rhs, &lhs, &mut dst.data)? }
+    unsafe { gemm_strided_batched_bf16(&dst.device.blas, cfg, &rhs, &lhs, &mut *dst.data)? }
     Ok(())
 }
 
@@ -744,10 +764,10 @@ pub fn flash_attn<T: WithDType>(
     let len_kv = len_kv as i32;
     let head_dim = head_dim as i32;
     let mut launch_args = dst.device.stream.launch_builder(&func);
-    launch_args.arg(&q.data);
-    launch_args.arg(&k.data);
-    launch_args.arg(&v.data);
-    launch_args.arg(&mut dst.data);
+    launch_args.arg(&*q.data);
+    launch_args.arg(&*k.data);
+    launch_args.arg(&*v.data);
+    launch_args.arg(&mut *dst.data);
     launch_args.arg(&bs);
     launch_args.arg(&len_q);
     launch_args.arg(&len_kv);
@@ -774,12 +794,12 @@ impl crate::Backend for Device {
 
     unsafe fn alloc_uninit<T: WithDType>(len: usize, dev: &Self) -> Result<Self::Storage<T>> {
         let data = unsafe { dev.stream.alloc::<T>(len) }?;
-        Ok(Storage { data, device: dev.clone() })
+        Ok(Storage { data: std::mem::ManuallyDrop::new(data), device: dev.clone() })
     }
 
     fn from_vec<T: WithDType>(v: Vec<T>, dev: &Self) -> Result<Self::Storage<T>> {
         let data = dev.cached_htod(&v)?;
-        Ok(Storage { data, device: dev.clone() })
+        Ok(Storage { data: std::mem::ManuallyDrop::new(data), device: dev.clone() })
     }
 
     fn fill<T: WithDType>(dst: &mut Self::Storage<T>, elem: T, len: usize) -> Result<()> {
@@ -790,7 +810,7 @@ impl crate::Backend for Device {
         let func = dst.device.get_func(&kname, PTXModule::Fill)?;
         let cfg = LaunchConfig::for_num_elems(len as u32);
         let mut launch_args = dst.device.stream.launch_builder(&func);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&mut *dst.data);
         launch_args.arg(&elem);
         launch_args.arg(&len);
         unsafe { launch_args.launch(cfg) }?;
@@ -810,7 +830,7 @@ impl crate::Backend for Device {
             let cfg = LaunchConfig::for_num_elems(len as u32);
             let mut launch_args = dst.device.stream.launch_builder(&func);
             launch_args.arg(&len);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&mut *dst.data);
             launch_args.arg(&range);
             launch_args.arg(&lo);
             unsafe { launch_args.launch(cfg) }?;
@@ -846,8 +866,8 @@ impl crate::Backend for Device {
         let cfg = LaunchConfig::for_num_elems(len as u32);
         let mut launch_args = dst.device.stream.launch_builder(&func);
         launch_args.arg(&len);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         unsafe { launch_args.launch(cfg) }?;
         Ok(())
     }
@@ -883,7 +903,7 @@ impl crate::Backend for Device {
         let cfg = LaunchConfig::for_num_elems(len as u32);
         let mut launch_args = dst.device.stream.launch_builder(&func);
         launch_args.arg(&len);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&mut *dst.data);
         if let Some(ref alpha) = alpha {
             launch_args.arg(alpha);
         }
@@ -909,8 +929,8 @@ impl crate::Backend for Device {
         let cfg = LaunchConfig::for_num_elems(len as u32);
         let mut launch_args = dst.device.stream.launch_builder(&func);
         launch_args.arg(&len);
-        launch_args.arg(&s.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*s.data);
+        launch_args.arg(&mut *dst.data);
         unsafe { launch_args.launch(cfg) }?;
         Ok(())
     }
@@ -942,8 +962,8 @@ impl crate::Backend for Device {
         let cfg = LaunchConfig::for_num_elems(len as u32);
         let mut launch_args = dst.device.stream.launch_builder(&func);
         launch_args.arg(&len);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         if let Some(ref alpha) = alpha {
             launch_args.arg(alpha);
         }
@@ -970,9 +990,9 @@ impl crate::Backend for Device {
         let cfg = LaunchConfig::for_num_elems(len as u32);
         let mut launch_args = dst.device.stream.launch_builder(&func);
         launch_args.arg(&len);
-        launch_args.arg(&lhs.data);
-        launch_args.arg(&rhs.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*lhs.data);
+        launch_args.arg(&*rhs.data);
+        launch_args.arg(&mut *dst.data);
         unsafe { launch_args.launch(cfg) }?;
         Ok(())
     }
@@ -994,8 +1014,8 @@ impl crate::Backend for Device {
         let cfg = LaunchConfig::for_num_elems(len as u32);
         let mut launch_args = dst.device.stream.launch_builder(&func);
         launch_args.arg(&len);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         launch_args.arg(&scale);
         launch_args.arg(&add);
         unsafe { launch_args.launch(cfg) }?;
@@ -1036,8 +1056,8 @@ impl crate::Backend for Device {
             launch_args.arg(&d_i);
             launch_args.arg(&d_j);
             launch_args.arg(&d_k);
-            launch_args.arg(&src.data);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&*src.data);
+            launch_args.arg(&mut *dst.data);
             unsafe { launch_args.launch(cfg) }?;
         }
         Ok(())
@@ -1111,8 +1131,8 @@ impl crate::Backend for Device {
         let mut launch_args = dst.device.stream.launch_builder(&func);
         launch_args.arg(&cos_slice);
         launch_args.arg(&sin_slice);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         launch_args.arg(&bh);
         launch_args.arg(&td);
         launch_args.arg(&d_u32);
@@ -1153,8 +1173,8 @@ impl crate::Backend for Device {
         let mut launch_args = dst.device.stream.launch_builder(&func);
         launch_args.arg(&cos_slice);
         launch_args.arg(&sin_slice);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         launch_args.arg(&bh);
         launch_args.arg(&td);
         launch_args.arg(&h_u32);
@@ -1289,8 +1309,8 @@ impl crate::Backend for Device {
             launch_args.arg(&cols);
             launch_args.arg(&src_stride);
             launch_args.arg(&src_offset_u32);
-            launch_args.arg(&src.data);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&*src.data);
+            launch_args.arg(&mut *dst.data);
             unsafe { launch_args.launch(cfg) }?;
             return Ok(());
         }
@@ -1309,8 +1329,8 @@ impl crate::Backend for Device {
         launch_args.arg(&num_dims_u32);
         launch_args.arg(&info_dev);
         launch_args.arg(&src_offset_u32);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         unsafe { launch_args.launch(cfg) }?;
         Ok(())
     }
@@ -1338,9 +1358,9 @@ impl crate::Backend for Device {
         let dst_dim_size_i32 = dst_dim_size as i32;
 
         let mut launch_args = dst.device.stream.launch_builder(&func);
-        launch_args.arg(&mut dst.data);
-        launch_args.arg(&src.data);
-        launch_args.arg(&ids.data);
+        launch_args.arg(&mut *dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&*ids.data);
         launch_args.arg(&numel_i32);
         launch_args.arg(&right_size_i32);
         launch_args.arg(&src_dim_size_i32);
@@ -1393,7 +1413,7 @@ impl crate::Backend for Device {
             launch_args.arg(&num_ids_i32);
             launch_args.arg(&right_size_i32);
             launch_args.arg(&src_dim_size_i32);
-            launch_args.arg(&ids.data);
+            launch_args.arg(&*ids.data);
             launch_args.arg(&src_slice);
             launch_args.arg(&mut dst_slice);
             unsafe { launch_args.launch(cfg) }?;
@@ -1419,7 +1439,7 @@ impl crate::Backend for Device {
         let offset = offset as u32;
 
         let mut launch_args = dst.device.stream.launch_builder(&func);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&mut *dst.data);
         launch_args.arg(&bh);
         launch_args.arg(&t1);
         launch_args.arg(&t2);
@@ -1448,8 +1468,8 @@ impl crate::Backend for Device {
         let cfg = LaunchConfig { block_dim, grid_dim, shared_mem_bytes: 0 };
 
         let mut launch_args = dst.device.stream.launch_builder(&func);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         launch_args.arg(&ncols);
         unsafe { launch_args.launch(cfg) }?;
         Ok(())
@@ -1477,9 +1497,9 @@ impl crate::Backend for Device {
         };
 
         let mut launch_args = dst.device.stream.launch_builder(&func);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
-        launch_args.arg(&alpha.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
+        launch_args.arg(&*alpha.data);
         launch_args.arg(&ncols);
         launch_args.arg(&block_size);
         launch_args.arg(&eps);
@@ -1512,10 +1532,10 @@ impl crate::Backend for Device {
         };
 
         let mut launch_args = dst.device.stream.launch_builder(&func);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
-        launch_args.arg(&weight.data);
-        launch_args.arg(&bias.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
+        launch_args.arg(&*weight.data);
+        launch_args.arg(&*bias.data);
         launch_args.arg(&ncols);
         launch_args.arg(&block_size);
         launch_args.arg(&eps);
@@ -1557,8 +1577,8 @@ impl crate::Backend for Device {
         launch_args.arg(&el_to_sum_per_block);
         launch_args.arg(&num_dims);
         launch_args.arg(&info_dev);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         unsafe { launch_args.launch(cfg) }?;
         Ok(())
     }
@@ -1596,8 +1616,8 @@ impl crate::Backend for Device {
         launch_args.arg(&el_to_sum_per_block);
         launch_args.arg(&num_dims);
         launch_args.arg(&info_dev);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         unsafe { launch_args.launch(cfg) }?;
         Ok(())
     }
@@ -1635,8 +1655,8 @@ impl crate::Backend for Device {
         launch_args.arg(&el_to_sum_per_block);
         launch_args.arg(&num_dims);
         launch_args.arg(&info_dev);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         unsafe { launch_args.launch(cfg) }?;
         Ok(())
     }
@@ -1671,8 +1691,8 @@ impl crate::Backend for Device {
         launch_args.arg(&el_to_sum_per_block);
         launch_args.arg(&num_dims);
         launch_args.arg(&info_dev);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         unsafe { launch_args.launch(cfg) }?;
         Ok(())
     }
@@ -1710,8 +1730,8 @@ impl crate::Backend for Device {
         launch_args.arg(&el_to_sum_per_block);
         launch_args.arg(&num_dims);
         launch_args.arg(&info_dev);
-        launch_args.arg(&src.data);
-        launch_args.arg(&mut dst.data);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&mut *dst.data);
         unsafe { launch_args.launch(cfg) }?;
         Ok(())
     }
@@ -1751,9 +1771,9 @@ impl crate::Backend for Device {
             let func = dst.device.get_func(&kname, PTXModule::Broadcast)?;
             let mut launch_args = dst.device.stream.launch_builder(&func);
             launch_args.arg(&numel);
-            launch_args.arg(&lhs.data);
-            launch_args.arg(&rhs.data);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&*lhs.data);
+            launch_args.arg(&*rhs.data);
+            launch_args.arg(&mut *dst.data);
             unsafe { launch_args.launch(cfg) }?;
         } else if lhs_no_zero && dst_shape.len() == 2 && rhs_strides == [0, 1] {
             // rhs broadcasts along first dim
@@ -1763,9 +1783,9 @@ impl crate::Backend for Device {
             let mut launch_args = dst.device.stream.launch_builder(&func);
             launch_args.arg(&numel);
             launch_args.arg(&dim1);
-            launch_args.arg(&lhs.data);
-            launch_args.arg(&rhs.data);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&*lhs.data);
+            launch_args.arg(&*rhs.data);
+            launch_args.arg(&mut *dst.data);
             unsafe { launch_args.launch(cfg) }?;
         } else if lhs_no_zero && dst_shape.len() == 2 && rhs_strides == [1, 0] {
             // rhs broadcasts along second dim
@@ -1775,9 +1795,9 @@ impl crate::Backend for Device {
             let mut launch_args = dst.device.stream.launch_builder(&func);
             launch_args.arg(&numel);
             launch_args.arg(&dim1);
-            launch_args.arg(&lhs.data);
-            launch_args.arg(&rhs.data);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&*lhs.data);
+            launch_args.arg(&*rhs.data);
+            launch_args.arg(&mut *dst.data);
             unsafe { launch_args.launch(cfg) }?;
         } else if rhs_no_zero && dst_shape.len() == 2 && lhs_strides == [0, 1] {
             // lhs broadcasts along first dim
@@ -1787,9 +1807,9 @@ impl crate::Backend for Device {
             let mut launch_args = dst.device.stream.launch_builder(&func);
             launch_args.arg(&numel);
             launch_args.arg(&dim1);
-            launch_args.arg(&lhs.data);
-            launch_args.arg(&rhs.data);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&*lhs.data);
+            launch_args.arg(&*rhs.data);
+            launch_args.arg(&mut *dst.data);
             unsafe { launch_args.launch(cfg) }?;
         } else if rhs_no_zero && dst_shape.len() == 2 && lhs_strides == [1, 0] {
             // lhs broadcasts along second dim
@@ -1799,9 +1819,9 @@ impl crate::Backend for Device {
             let mut launch_args = dst.device.stream.launch_builder(&func);
             launch_args.arg(&numel);
             launch_args.arg(&dim1);
-            launch_args.arg(&lhs.data);
-            launch_args.arg(&rhs.data);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&*lhs.data);
+            launch_args.arg(&*rhs.data);
+            launch_args.arg(&mut *dst.data);
             unsafe { launch_args.launch(cfg) }?;
         } else if lhs_no_zero
             && dst_shape.len() == 3
@@ -1818,9 +1838,9 @@ impl crate::Backend for Device {
             launch_args.arg(&numel);
             launch_args.arg(&dim12);
             launch_args.arg(&dim2);
-            launch_args.arg(&lhs.data);
-            launch_args.arg(&rhs.data);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&*lhs.data);
+            launch_args.arg(&*rhs.data);
+            launch_args.arg(&mut *dst.data);
             unsafe { launch_args.launch(cfg) }?;
         } else if rhs_no_zero
             && dst_shape.len() == 3
@@ -1837,9 +1857,9 @@ impl crate::Backend for Device {
             launch_args.arg(&numel);
             launch_args.arg(&dim12);
             launch_args.arg(&dim2);
-            launch_args.arg(&lhs.data);
-            launch_args.arg(&rhs.data);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&*lhs.data);
+            launch_args.arg(&*rhs.data);
+            launch_args.arg(&mut *dst.data);
             unsafe { launch_args.launch(cfg) }?;
         } else {
             // General strided case
@@ -1859,9 +1879,9 @@ impl crate::Backend for Device {
             launch_args.arg(&numel);
             launch_args.arg(&num_dims_u32);
             launch_args.arg(&info_dev);
-            launch_args.arg(&lhs.data);
-            launch_args.arg(&rhs.data);
-            launch_args.arg(&mut dst.data);
+            launch_args.arg(&*lhs.data);
+            launch_args.arg(&*rhs.data);
+            launch_args.arg(&mut *dst.data);
             unsafe { launch_args.launch(cfg) }?;
         }
         Ok(())
@@ -2020,7 +2040,7 @@ fn conv1d_im2col<T: WithDTypeF>(
     launch_args.arg(&stride);
     launch_args.arg(&padding);
     launch_args.arg(&dilation);
-    launch_args.arg(&src.data);
+    launch_args.arg(&*src.data);
     launch_args.arg(&mut col);
     unsafe { launch_args.launch(cfg) }?;
 
@@ -2039,7 +2059,7 @@ fn conv1d_im2col<T: WithDTypeF>(
     // We want: result = col @ kernel^T
     // cuBLAS uses column-major, so we compute: result^T = kernel @ col^T
     // Which gives us result in row-major as [L_out, out_channels]
-    conv1d_gemm(&dst.device, &col, &kernel.data, &mut result, batch, out_length, out_channels, k)?;
+    conv1d_gemm(&dst.device, &col, &*kernel.data, &mut result, batch, out_length, out_channels, k)?;
 
     // Step 3: Transpose from [B, L_out, out_channels] to [B, out_channels, L_out]
     let kname = format!("transpose_blc_bcl_{}", T::DTYPE.cuda_name());
@@ -2058,7 +2078,7 @@ fn conv1d_im2col<T: WithDTypeF>(
     launch_args.arg(&out_length);
     launch_args.arg(&out_channels);
     launch_args.arg(&result);
-    launch_args.arg(&mut dst.data);
+    launch_args.arg(&mut *dst.data);
     unsafe { launch_args.launch(cfg) }?;
 
     Ok(())
@@ -2289,9 +2309,9 @@ fn conv1d_direct<T: WithDTypeF>(
     launch_args.arg(&padding);
     launch_args.arg(&dilation);
     launch_args.arg(&groups);
-    launch_args.arg(&src.data);
-    launch_args.arg(&kernel.data);
-    launch_args.arg(&mut dst.data);
+    launch_args.arg(&*src.data);
+    launch_args.arg(&*kernel.data);
+    launch_args.arg(&mut *dst.data);
     unsafe { launch_args.launch(cfg) }?;
 
     Ok(())
@@ -2342,7 +2362,7 @@ fn conv_transpose1d_col2im<T: WithDTypeF>(
     let mut launch_args = dst.device.stream.launch_builder(&func);
     launch_args.arg(&in_channels);
     launch_args.arg(&length);
-    launch_args.arg(&src.data);
+    launch_args.arg(&*src.data);
     launch_args.arg(&mut src_transposed);
     unsafe { launch_args.launch(cfg) }?;
 
@@ -2355,7 +2375,7 @@ fn conv_transpose1d_col2im<T: WithDTypeF>(
     conv_transpose1d_gemm(
         &dst.device,
         &src_transposed,
-        &kernel.data,
+        &*kernel.data,
         &mut col,
         batch,
         length,
@@ -2385,7 +2405,7 @@ fn conv_transpose1d_col2im<T: WithDTypeF>(
     launch_args.arg(&kernel_size);
     launch_args.arg(&stride);
     launch_args.arg(&col);
-    launch_args.arg(&mut dst.data);
+    launch_args.arg(&mut *dst.data);
     unsafe { launch_args.launch(cfg) }?;
 
     Ok(())
@@ -2578,9 +2598,9 @@ fn conv_transpose1d_direct<T: WithDTypeF>(
     launch_args.arg(&output_padding);
     launch_args.arg(&dilation);
     launch_args.arg(&groups);
-    launch_args.arg(&src.data);
-    launch_args.arg(&kernel.data);
-    launch_args.arg(&mut dst.data);
+    launch_args.arg(&*src.data);
+    launch_args.arg(&*kernel.data);
+    launch_args.arg(&mut *dst.data);
     unsafe { launch_args.launch(cfg) }?;
 
     Ok(())

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -1969,6 +1969,7 @@ impl crate::Backend for Device {
                 kernel,
                 None,
                 None,
+                None,
                 batch,
                 in_channels,
                 out_channels,
@@ -2100,6 +2101,7 @@ impl crate::Backend for Device {
                 kernel,
                 bias.map(|b| &*b.data),
                 None,
+                None,
                 batch,
                 in_channels,
                 out_channels,
@@ -2131,12 +2133,13 @@ impl crate::Backend for Device {
         }
     }
 
-    fn conv1d_with_bias_snake<T: WithDTypeF>(
+    fn conv1d_fused<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,
         kernel: &Self::Storage<T>,
         bias: Option<&Self::Storage<T>>,
         snake: Option<(&Self::Storage<T>, &Self::Storage<T>)>,
+        residual: Option<&Self::Storage<T>>,
         batch: usize,
         in_channels: usize,
         out_channels: usize,
@@ -2147,51 +2150,52 @@ impl crate::Backend for Device {
         padding: usize,
         dilation: usize,
         groups: usize,
-    ) -> Result<(bool, bool)> {
-        // Only the im2col path owns its store epilogue, so that is the only one
-        // that can fold the activation in. cuDNN and the direct kernel fall
-        // back to the plain contract.
-        let fusable = groups == 1 && !cudnn_conv::enabled();
-        match (snake, fusable) {
-            (Some((alpha, beta)), true) if bias.is_some() => {
-                conv1d_im2col(
-                    dst,
-                    src,
-                    kernel,
-                    bias.map(|b| &*b.data),
-                    Some((&alpha.data, &beta.data)),
-                    batch,
-                    in_channels,
-                    out_channels,
-                    length,
-                    out_length,
-                    kernel_size,
-                    stride,
-                    padding,
-                    dilation,
-                )?;
-                Ok((true, true))
-            }
-            _ => {
-                let bias_applied = Self::conv1d_with_bias(
-                    dst,
-                    src,
-                    kernel,
-                    bias,
-                    batch,
-                    in_channels,
-                    out_channels,
-                    length,
-                    out_length,
-                    kernel_size,
-                    stride,
-                    padding,
-                    dilation,
-                    groups,
-                )?;
-                Ok((bias_applied, false))
-            }
+    ) -> Result<crate::backend::ConvFused> {
+        // Only the im2col path owns its store epilogue, so it is the only one
+        // that can fold anything in; cuDNN and the direct kernel own theirs.
+        let fusable = groups == 1 && !cudnn_conv::enabled() && bias.is_some();
+        let want = snake.is_some() || residual.is_some();
+        if fusable && want {
+            conv1d_im2col(
+                dst,
+                src,
+                kernel,
+                bias.map(|b| &*b.data),
+                snake.map(|(a, b)| (&*a.data, &*b.data)),
+                residual.map(|r| &*r.data),
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+            )?;
+            return Ok(crate::backend::ConvFused {
+                bias: true,
+                snake: snake.is_some(),
+                residual: residual.is_some(),
+            });
         }
+        let bias_applied = Self::conv1d_with_bias(
+            dst,
+            src,
+            kernel,
+            bias,
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+        )?;
+        Ok(crate::backend::ConvFused { bias: bias_applied, snake: false, residual: false })
     }
 
     fn conv_transpose1d_with_bias<T: WithDTypeF>(
@@ -2283,6 +2287,7 @@ fn conv1d_im2col<T: WithDTypeF>(
     kernel: &Storage<T>,
     bias: Option<&CudaSlice<T>>,
     snake: Option<(&CudaSlice<T>, &CudaSlice<T>)>,
+    residual: Option<&CudaSlice<T>>,
     batch: usize,
     in_channels: usize,
     out_channels: usize,
@@ -2345,9 +2350,11 @@ fn conv1d_im2col<T: WithDTypeF>(
     // the seanet decoder always uses; a bias-less snake falls back to a
     // separate activation pass (see `Tensor::conv1d_snake`).
     let snake = snake.filter(|_| bias.is_some());
-    let kname = match (bias, snake) {
-        (Some(_), Some(_)) => format!("transpose_blc_bcl_bias_snake_{}", T::DTYPE.cuda_name()),
-        (Some(_), None) => format!("transpose_blc_bcl_bias_{}", T::DTYPE.cuda_name()),
+    let residual = residual.filter(|_| bias.is_some());
+    let fused = snake.is_some() || residual.is_some();
+    let kname = match (bias, fused) {
+        (Some(_), true) => format!("transpose_blc_bcl_fused_{}", T::DTYPE.cuda_name()),
+        (Some(_), false) => format!("transpose_blc_bcl_bias_{}", T::DTYPE.cuda_name()),
         (None, _) => format!("transpose_blc_bcl_{}", T::DTYPE.cuda_name()),
     };
     let func = dst.device.get_func(&kname, PTXModule::Conv)?;
@@ -2364,27 +2371,30 @@ fn conv1d_im2col<T: WithDTypeF>(
     let mut launch_args = dst.device.stream.launch_builder(&func);
     launch_args.arg(&out_length);
     launch_args.arg(&out_channels);
-    launch_args.arg(&result);
-    match snake {
-        None => {
-            if let Some(bias) = bias {
-                launch_args.arg(bias);
-            }
-        }
-        Some((alpha, beta)) => {
-            // `snake` was filtered to the bias case above, so bias is Some here.
-            let bias = match bias {
-                Some(bias) => bias,
-                None => crate::bail!("fused snake epilogue requires a bias"),
-            };
+    if !fused {
+        launch_args.arg(&result);
+        if let Some(bias) = bias {
             launch_args.arg(bias);
-            launch_args.arg(alpha);
-            launch_args.arg(beta);
-            launch_args.arg(&mut *dst.data);
-            unsafe { launch_args.launch(cfg) }?;
-            return Ok(());
         }
+        launch_args.arg(&mut *dst.data);
+        unsafe { launch_args.launch(cfg) }?;
+        return Ok(());
     }
+    // Flag-driven fused epilogue: unused pointers are passed as the bias, which
+    // is always present on this path, so no null pointer ever reaches a kernel.
+    let bias = match bias {
+        Some(bias) => bias,
+        None => crate::bail!("fused conv epilogue requires a bias"),
+    };
+    let flags: usize = usize::from(snake.is_some()) | (usize::from(residual.is_some()) << 1);
+    let (alpha, beta) = snake.unwrap_or((bias, bias));
+    let residual = residual.unwrap_or(bias);
+    launch_args.arg(&flags);
+    launch_args.arg(&result);
+    launch_args.arg(bias);
+    launch_args.arg(alpha);
+    launch_args.arg(beta);
+    launch_args.arg(residual);
     launch_args.arg(&mut *dst.data);
     unsafe { launch_args.launch(cfg) }?;
 

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -2048,7 +2048,7 @@ impl crate::Backend for Device {
             let kernel = unsafe { &*(kernel as *const Storage<T> as *const Storage<f32>) };
             let bias = bias
                 .map(|b| unsafe { &*(&*b.data as *const CudaSlice<T> as *const CudaSlice<f32>) });
-            cudnn_conv::conv1d_f32(
+            return cudnn_conv::conv1d_f32(
                 dst,
                 src,
                 kernel,
@@ -2062,8 +2062,7 @@ impl crate::Backend for Device {
                 stride,
                 padding,
                 dilation,
-            )?;
-            return Ok(bias.is_some());
+            );
         }
         if groups == 1 {
             conv1d_im2col(

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -1935,6 +1935,7 @@ impl crate::Backend for Device {
                 dst,
                 src,
                 kernel,
+                None,
                 batch,
                 in_channels,
                 out_channels,
@@ -1992,6 +1993,7 @@ impl crate::Backend for Device {
                 dst,
                 src,
                 kernel,
+                None,
                 batch,
                 in_channels,
                 out_channels,
@@ -2019,6 +2021,111 @@ impl crate::Backend for Device {
             )
         }
     }
+
+    fn conv1d_with_bias<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        bias: Option<&Self::Storage<T>>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        if groups == 1 {
+            conv1d_im2col(
+                dst,
+                src,
+                kernel,
+                bias.map(|b| &*b.data),
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+            )?;
+            Ok(bias.is_some())
+        } else {
+            conv1d_direct(
+                dst,
+                src,
+                kernel,
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                groups,
+            )?;
+            Ok(false)
+        }
+    }
+
+    fn conv_transpose1d_with_bias<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        kernel: &Self::Storage<T>,
+        bias: Option<&Self::Storage<T>>,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        length: usize,
+        out_length: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: usize,
+        output_padding: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        let can_use_col2im = groups == 1 && padding == 0 && output_padding == 0;
+        if can_use_col2im {
+            conv_transpose1d_col2im(
+                dst,
+                src,
+                kernel,
+                bias.map(|b| &*b.data),
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+            )?;
+            Ok(bias.is_some())
+        } else {
+            conv_transpose1d_direct(
+                dst,
+                src,
+                kernel,
+                batch,
+                in_channels,
+                out_channels,
+                length,
+                out_length,
+                kernel_size,
+                stride,
+                padding,
+                output_padding,
+                groups,
+            )?;
+            Ok(false)
+        }
+    }
 }
 
 // ============================================================================
@@ -2029,6 +2136,7 @@ fn conv1d_im2col<T: WithDTypeF>(
     dst: &mut Storage<T>,
     src: &Storage<T>,
     kernel: &Storage<T>,
+    bias: Option<&CudaSlice<T>>,
     batch: usize,
     in_channels: usize,
     out_channels: usize,
@@ -2085,8 +2193,12 @@ fn conv1d_im2col<T: WithDTypeF>(
     // Which gives us result in row-major as [L_out, out_channels]
     conv1d_gemm(&dst.device, &col, &*kernel.data, &mut result, batch, out_length, out_channels, k)?;
 
-    // Step 3: Transpose from [B, L_out, out_channels] to [B, out_channels, L_out]
-    let kname = format!("transpose_blc_bcl_{}", T::DTYPE.cuda_name());
+    // Step 3: Transpose from [B, L_out, out_channels] to [B, out_channels, L_out],
+    // fusing the per-channel bias into the store when provided.
+    let kname = match bias {
+        Some(_) => format!("transpose_blc_bcl_bias_{}", T::DTYPE.cuda_name()),
+        None => format!("transpose_blc_bcl_{}", T::DTYPE.cuda_name()),
+    };
     let func = dst.device.get_func(&kname, PTXModule::Conv)?;
     let cfg = LaunchConfig {
         grid_dim: (
@@ -2102,6 +2214,9 @@ fn conv1d_im2col<T: WithDTypeF>(
     launch_args.arg(&out_length);
     launch_args.arg(&out_channels);
     launch_args.arg(&result);
+    if let Some(bias) = bias {
+        launch_args.arg(bias);
+    }
     launch_args.arg(&mut *dst.data);
     unsafe { launch_args.launch(cfg) }?;
 
@@ -2349,6 +2464,7 @@ fn conv_transpose1d_col2im<T: WithDTypeF>(
     dst: &mut Storage<T>,
     src: &Storage<T>,
     kernel: &Storage<T>,
+    bias: Option<&CudaSlice<T>>,
     batch: usize,
     in_channels: usize,
     out_channels: usize,
@@ -2407,10 +2523,13 @@ fn conv_transpose1d_col2im<T: WithDTypeF>(
         in_channels,
     )?;
 
-    // Step 3: Col2Im transformation
+    // Step 3: Col2Im transformation, fusing the per-channel bias when provided
     // col: [B, L_in, C_out * K] = [B, L_in, C_out, K]
     // output: [B, C_out, L_out]
-    let kname = format!("col2im1d_{}", T::DTYPE.cuda_name());
+    let kname = match bias {
+        Some(_) => format!("col2im1d_bias_{}", T::DTYPE.cuda_name()),
+        None => format!("col2im1d_{}", T::DTYPE.cuda_name()),
+    };
     let func = dst.device.get_func(&kname, PTXModule::Conv)?;
     let cfg = LaunchConfig {
         grid_dim: (
@@ -2429,6 +2548,9 @@ fn conv_transpose1d_col2im<T: WithDTypeF>(
     launch_args.arg(&kernel_size);
     launch_args.arg(&stride);
     launch_args.arg(&col);
+    if let Some(bias) = bias {
+        launch_args.arg(bias);
+    }
     launch_args.arg(&mut *dst.data);
     unsafe { launch_args.launch(cfg) }?;
 

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -2072,7 +2072,11 @@ impl crate::Backend for Device {
         dilation: usize,
         groups: usize,
     ) -> Result<bool> {
-        if cudnn_conv::enabled() && groups == 1 && T::DTYPE == DType::F32 {
+        if cudnn_conv::enabled()
+            && groups == 1
+            && T::DTYPE == DType::F32
+            && kernel_size >= cudnn_conv::min_kernel_size()
+        {
             let dst = unsafe { &mut *(dst as *mut Storage<T> as *mut Storage<f32>) };
             let src = unsafe { &*(src as *const Storage<T> as *const Storage<f32>) };
             let kernel = unsafe { &*(kernel as *const Storage<T> as *const Storage<f32>) };
@@ -2153,7 +2157,8 @@ impl crate::Backend for Device {
     ) -> Result<crate::backend::ConvFused> {
         // Only the im2col path owns its store epilogue, so it is the only one
         // that can fold anything in; cuDNN and the direct kernel own theirs.
-        let fusable = groups == 1 && !cudnn_conv::enabled() && bias.is_some();
+        let cudnn_takes_it = cudnn_conv::enabled() && kernel_size >= cudnn_conv::min_kernel_size();
+        let fusable = groups == 1 && !cudnn_takes_it && bias.is_some();
         let want = snake.is_some() || residual.is_some();
         if fusable && want {
             conv1d_im2col(
@@ -2215,6 +2220,7 @@ impl crate::Backend for Device {
         groups: usize,
     ) -> Result<bool> {
         if cudnn_conv::enabled()
+            && !cudnn_conv::fwd_only()
             && groups == 1
             && padding == 0
             && output_padding == 0

--- a/xn-core/src/cuda_backend/mod.rs
+++ b/xn-core/src/cuda_backend/mod.rs
@@ -1507,6 +1507,30 @@ impl crate::Backend for Device {
         Ok(())
     }
 
+    fn snake<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        src: &Self::Storage<T>,
+        alpha: &Self::Storage<T>,
+        beta_scale: &Self::Storage<T>,
+        channels: usize,
+        row_len: usize,
+        numel: usize,
+    ) -> Result<()> {
+        let kname = kernel_name::<T>("snake");
+        let func = dst.device.get_func(&kname, PTXModule::Broadcast)?;
+        let cfg = LaunchConfig::for_num_elems(numel as u32);
+        let mut launch_args = dst.device.stream.launch_builder(&func);
+        launch_args.arg(&numel);
+        launch_args.arg(&channels);
+        launch_args.arg(&row_len);
+        launch_args.arg(&*src.data);
+        launch_args.arg(&*alpha.data);
+        launch_args.arg(&*beta_scale.data);
+        launch_args.arg(&mut *dst.data);
+        unsafe { launch_args.launch(cfg) }?;
+        Ok(())
+    }
+
     fn layer_norm<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/src/cuda_backend/quantization.rs
+++ b/xn-core/src/cuda_backend/quantization.rs
@@ -53,7 +53,7 @@ impl Fp8Tensor {
         let hidden_size = shape.dim(crate::D::Minus1)?;
         let num_tokens: usize = shape.elem_count() / hidden_size;
         let storage = src.storage()?;
-        quantize_fp8(&storage.device, &storage.data, num_tokens, hidden_size, shape.clone())
+        quantize_fp8(&storage.device, &*storage.data, num_tokens, hidden_size, shape.clone())
     }
 
     /// Quantize a `Tensor<T, Device>` into an `Fp8Tensor` using dynamic per-token scaling.
@@ -64,7 +64,7 @@ impl Fp8Tensor {
         let storage = src.storage()?;
         quantize_fp8_per_token(
             &storage.device,
-            &storage.data,
+            &*storage.data,
             num_tokens,
             hidden_size,
             shape.clone(),
@@ -104,7 +104,8 @@ impl Fp8Tensor {
             }
         }
 
-        let storage = Storage { data: out, device: self.device.clone() };
+        let storage =
+            Storage { data: std::mem::ManuallyDrop::new(out), device: self.device.clone() };
         Ok(Tensor {
             data: Arc::new(RwLock::new(storage)),
             shape: self.shape.clone(),
@@ -172,7 +173,8 @@ impl Fp8Tensor {
         )?;
 
         let out_shape: Shape = (m, n).into();
-        let storage = Storage { data: out, device: self.device.clone() };
+        let storage =
+            Storage { data: std::mem::ManuallyDrop::new(out), device: self.device.clone() };
         Ok(Tensor {
             data: Arc::new(RwLock::new(storage)),
             shape: out_shape,

--- a/xn-core/src/error.rs
+++ b/xn-core/src/error.rs
@@ -83,6 +83,10 @@ pub enum Error {
     #[cfg(feature = "cuda")]
     #[error(transparent)]
     CublasLt(cudarc::cublaslt::result::CublasError),
+
+    #[cfg(feature = "cuda")]
+    #[error(transparent)]
+    Cudnn(cudarc::cudnn::CudnnError),
 }
 
 #[cfg(feature = "cuda")]
@@ -103,6 +107,13 @@ impl From<cudarc::curand::result::CurandError> for Error {
 impl From<cudarc::cublas::result::CublasError> for Error {
     fn from(value: cudarc::cublas::result::CublasError) -> Self {
         Self::Cublas(value).bt()
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl From<cudarc::cudnn::CudnnError> for Error {
+    fn from(value: cudarc::cudnn::CudnnError) -> Self {
+        Self::Cudnn(value).bt()
     }
 }
 

--- a/xn-core/src/inplace_ops.rs
+++ b/xn-core/src/inplace_ops.rs
@@ -910,22 +910,23 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
     /// returns whether the backend applied the bias.
     #[allow(clippy::too_many_arguments)]
     /// Like [`Tensor::conv1d_with_bias_`] but also asks the backend to fold a
-    /// per-channel snake activation into the epilogue. Returns
-    /// `(bias_applied, snake_applied)`.
+    /// per-channel snake activation and/or a residual add into the epilogue.
+    /// Reports what was fused so the caller can apply the rest.
     #[allow(clippy::too_many_arguments)]
-    pub fn conv1d_with_bias_snake_(
+    pub fn conv1d_fused_(
         &self,
         src: &Self,
         kernel: &Self,
         bias: Option<&Self>,
         snake: Option<(&Self, &Self)>,
+        residual: Option<&Self>,
         stride: usize,
         padding: usize,
         dilation: usize,
         groups: usize,
-    ) -> Result<(bool, bool)> {
-        self.check_not_same_storage(src, "conv1d_snake")?;
-        self.check_not_same_storage(kernel, "conv1d_snake")?;
+    ) -> Result<crate::backend::ConvFused> {
+        self.check_not_same_storage(src, "conv1d_fused")?;
+        self.check_not_same_storage(kernel, "conv1d_fused")?;
         let src_dims = src.dims();
         let kernel_dims = kernel.dims();
         let batch = src_dims[0];
@@ -934,12 +935,22 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         let out_channels = kernel_dims[0];
         let kernel_size = kernel_dims[2];
         let out_length = (length + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1;
-        if let Some((alpha, beta)) = snake {
-            if alpha.elem_count() != out_channels || beta.elem_count() != out_channels {
+        if let Some((alpha, beta)) = snake
+            && (alpha.elem_count() != out_channels || beta.elem_count() != out_channels)
+        {
+            crate::bail!(
+                "conv1d_fused expects alpha/beta with {out_channels} elements, got {:?} and {:?}",
+                alpha.shape(),
+                beta.shape()
+            )
+        }
+        if let Some(residual) = residual {
+            self.check_not_same_storage(residual, "conv1d_fused")?;
+            if residual.dims() != [batch, out_channels, out_length] {
                 crate::bail!(
-                    "conv1d_snake expects alpha/beta with {out_channels} elements, got {:?} and {:?}",
-                    alpha.shape(),
-                    beta.shape()
+                    "conv1d_fused residual shape mismatch: expected [{batch}, {out_channels}, \
+                     {out_length}], got {:?}",
+                    residual.shape()
                 )
             }
         }
@@ -952,12 +963,14 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
             None => None,
             Some((alpha, beta)) => Some((alpha.storage()?, beta.storage()?)),
         };
-        B::conv1d_with_bias_snake(
+        let residual_data = residual.map(|r| r.storage()).transpose()?;
+        B::conv1d_fused(
             &mut *dst,
             &*src_data,
             &*kernel_data,
             bias_data.as_deref(),
             snake_data.as_ref().map(|(a, b)| (&**a, &**b)),
+            residual_data.as_deref(),
             batch,
             in_channels,
             out_channels,

--- a/xn-core/src/inplace_ops.rs
+++ b/xn-core/src/inplace_ops.rs
@@ -411,6 +411,59 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         Ok(())
     }
 
+    /// Snake activation from `src` into a window of `self`:
+    /// `self[b, c, offset .. offset + src_len] = snake(src)`. `self` and `src`
+    /// must share batch and channel counts; `self` rows may be longer.
+    pub fn snake_offset_(
+        &self,
+        src: &Self,
+        alpha: &Self,
+        beta_scale: &Self,
+        offset: usize,
+    ) -> Result<()> {
+        self.check_not_same_storage(src, "snake_offset_")?;
+        let (db, dc, dst_len) = match *self.shape.dims() {
+            [b, c, l] => (b, c, l),
+            _ => crate::bail!("snake_offset_ expects a 3D dst, got {:?}", self.shape()),
+        };
+        let (sb, sc, src_len) = match *src.shape.dims() {
+            [b, c, l] => (b, c, l),
+            _ => crate::bail!("snake_offset_ expects a 3D src, got {:?}", src.shape()),
+        };
+        if db != sb || dc != sc {
+            crate::bail!(
+                "snake_offset_ batch/channel mismatch: dst {:?} src {:?}",
+                self.shape(),
+                src.shape()
+            )
+        }
+        if offset + src_len > dst_len {
+            crate::bail!("snake_offset_ window {offset}+{src_len} exceeds dst len {dst_len}")
+        }
+        if alpha.elem_count() != dc || beta_scale.elem_count() != dc {
+            crate::bail!(
+                "snake_offset_ expects alpha/beta_scale with {dc} elements, got {:?} and {:?}",
+                alpha.shape(),
+                beta_scale.shape()
+            )
+        }
+        let mut dst = self.storage_mut()?;
+        let src_data = src.storage()?;
+        let alpha_data = alpha.storage()?;
+        let beta_data = beta_scale.storage()?;
+        B::snake_offset(
+            &mut *dst,
+            &*src_data,
+            &*alpha_data,
+            &*beta_data,
+            dc,
+            src_len,
+            dst_len,
+            offset,
+            src.elem_count(),
+        )
+    }
+
     pub fn layer_norm_(
         &self,
         src: &Self,

--- a/xn-core/src/inplace_ops.rs
+++ b/xn-core/src/inplace_ops.rs
@@ -376,6 +376,41 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         Ok(())
     }
 
+    /// Fused snake activation: self = src + beta_scale[c] * sin(alpha[c] * src)^2
+    /// src has shape (b, c, l); alpha and beta_scale have c elements each
+    /// (trailing singleton dims are accepted, e.g. (1, c, 1)).
+    pub fn snake_(&self, src: &Self, alpha: &Self, beta_scale: &Self) -> Result<()> {
+        self.check_not_same_storage(src, "snake_")?;
+        self.check_not_same_storage(alpha, "snake_")?;
+        self.check_not_same_storage(beta_scale, "snake_")?;
+        check_same_shape(&self.shape, &src.shape, "snake_ src")?;
+        let (_b, channels, row_len) = match *self.shape.dims() {
+            [b, c, l] => (b, c, l),
+            _ => crate::bail!("snake_ expects a 3D tensor, got shape {:?}", self.shape()),
+        };
+        if alpha.elem_count() != channels || beta_scale.elem_count() != channels {
+            crate::bail!(
+                "snake_ expects alpha/beta_scale with {channels} elements, got {:?} and {:?}",
+                alpha.shape(),
+                beta_scale.shape()
+            );
+        }
+        let mut dst = self.storage_mut()?;
+        let src_data = src.storage()?;
+        let alpha_data = alpha.storage()?;
+        let beta_scale_data = beta_scale.storage()?;
+        B::snake(
+            &mut *dst,
+            &*src_data,
+            &*alpha_data,
+            &*beta_scale_data,
+            channels,
+            row_len,
+            self.elem_count(),
+        )?;
+        Ok(())
+    }
+
     pub fn layer_norm_(
         &self,
         src: &Self,

--- a/xn-core/src/inplace_ops.rs
+++ b/xn-core/src/inplace_ops.rs
@@ -852,6 +852,98 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
             groups,
         )
     }
+
+    /// Conv1d with the bias-fusion contract of [`crate::Backend::conv1d_with_bias`]:
+    /// returns whether the backend applied the bias.
+    #[allow(clippy::too_many_arguments)]
+    pub fn conv1d_with_bias_(
+        &self,
+        src: &Self,
+        kernel: &Self,
+        bias: Option<&Self>,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        self.check_not_same_storage(src, "conv1d_")?;
+        self.check_not_same_storage(kernel, "conv1d_")?;
+        let src_dims = src.dims();
+        let kernel_dims = kernel.dims();
+        let batch = src_dims[0];
+        let in_channels = src_dims[1];
+        let length = src_dims[2];
+        let out_channels = kernel_dims[0];
+        let kernel_size = kernel_dims[2];
+        let out_length = (length + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1;
+
+        let mut dst = self.storage_mut()?;
+        let src_data = src.storage()?;
+        let kernel_data = kernel.storage()?;
+        let bias_data = bias.map(|b| b.storage()).transpose()?;
+        B::conv1d_with_bias(
+            &mut *dst,
+            &*src_data,
+            &*kernel_data,
+            bias_data.as_deref(),
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+        )
+    }
+
+    /// ConvTranspose1d with the bias-fusion contract of
+    /// [`crate::Backend::conv_transpose1d_with_bias`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn conv_transpose1d_with_bias_(
+        &self,
+        src: &Self,
+        kernel: &Self,
+        bias: Option<&Self>,
+        stride: usize,
+        padding: usize,
+        output_padding: usize,
+        groups: usize,
+    ) -> Result<bool> {
+        self.check_not_same_storage(src, "conv_transpose1d_")?;
+        self.check_not_same_storage(kernel, "conv_transpose1d_")?;
+        let src_dims = src.dims();
+        let kernel_dims = kernel.dims();
+        let batch = src_dims[0];
+        let in_channels = src_dims[1];
+        let length = src_dims[2];
+        let out_channels = kernel_dims[1] * groups;
+        let kernel_size = kernel_dims[2];
+        let out_length = (length - 1) * stride + kernel_size + output_padding - 2 * padding;
+
+        let mut dst = self.storage_mut()?;
+        let src_data = src.storage()?;
+        let kernel_data = kernel.storage()?;
+        let bias_data = bias.map(|b| b.storage()).transpose()?;
+        B::conv_transpose1d_with_bias(
+            &mut *dst,
+            &*src_data,
+            &*kernel_data,
+            bias_data.as_deref(),
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            output_padding,
+            groups,
+        )
+    }
 }
 
 /// Compute broadcast strides for lhs and rhs given the output shape.

--- a/xn-core/src/inplace_ops.rs
+++ b/xn-core/src/inplace_ops.rs
@@ -856,6 +856,68 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
     /// Conv1d with the bias-fusion contract of [`crate::Backend::conv1d_with_bias`]:
     /// returns whether the backend applied the bias.
     #[allow(clippy::too_many_arguments)]
+    /// Like [`Tensor::conv1d_with_bias_`] but also asks the backend to fold a
+    /// per-channel snake activation into the epilogue. Returns
+    /// `(bias_applied, snake_applied)`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn conv1d_with_bias_snake_(
+        &self,
+        src: &Self,
+        kernel: &Self,
+        bias: Option<&Self>,
+        snake: Option<(&Self, &Self)>,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<(bool, bool)> {
+        self.check_not_same_storage(src, "conv1d_snake")?;
+        self.check_not_same_storage(kernel, "conv1d_snake")?;
+        let src_dims = src.dims();
+        let kernel_dims = kernel.dims();
+        let batch = src_dims[0];
+        let in_channels = src_dims[1];
+        let length = src_dims[2];
+        let out_channels = kernel_dims[0];
+        let kernel_size = kernel_dims[2];
+        let out_length = (length + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1;
+        if let Some((alpha, beta)) = snake {
+            if alpha.elem_count() != out_channels || beta.elem_count() != out_channels {
+                crate::bail!(
+                    "conv1d_snake expects alpha/beta with {out_channels} elements, got {:?} and {:?}",
+                    alpha.shape(),
+                    beta.shape()
+                )
+            }
+        }
+
+        let mut dst = self.storage_mut()?;
+        let src_data = src.storage()?;
+        let kernel_data = kernel.storage()?;
+        let bias_data = bias.map(|b| b.storage()).transpose()?;
+        let snake_data = match snake {
+            None => None,
+            Some((alpha, beta)) => Some((alpha.storage()?, beta.storage()?)),
+        };
+        B::conv1d_with_bias_snake(
+            &mut *dst,
+            &*src_data,
+            &*kernel_data,
+            bias_data.as_deref(),
+            snake_data.as_ref().map(|(a, b)| (&**a, &**b)),
+            batch,
+            in_channels,
+            out_channels,
+            length,
+            out_length,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            groups,
+        )
+    }
+
     pub fn conv1d_with_bias_(
         &self,
         src: &Self,

--- a/xn-core/src/metal_backend/backend_impl.rs
+++ b/xn-core/src/metal_backend/backend_impl.rs
@@ -539,6 +539,18 @@ impl crate::Backend for Device {
         dst.device.dispatch(&format!("softmax_{dt}"), &[src.buf(), dst.buf()], &push, d as u32)
     }
 
+    fn snake<T: WithDTypeF>(
+        _dst: &mut Self::Storage<T>,
+        _src: &Self::Storage<T>,
+        _alpha: &Self::Storage<T>,
+        _beta_scale: &Self::Storage<T>,
+        _channels: usize,
+        _row_len: usize,
+        _numel: usize,
+    ) -> Result<()> {
+        crate::bail!("snake is not implemented for this backend")
+    }
+
     fn rms_norm<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/src/ops.rs
+++ b/xn-core/src/ops.rs
@@ -248,6 +248,15 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         Ok(result)
     }
 
+    /// Fused snake activation: y = x + beta_scale[c] * sin(alpha[c] * x)^2
+    /// self has shape (b, c, l); alpha and beta_scale have c elements each.
+    #[tracing::instrument(skip_all)]
+    pub fn snake(&self, alpha: &Self, beta_scale: &Self) -> Result<Self> {
+        let result = unsafe { Tensor::alloc_uninit(self.shape.clone(), self.device()) }?;
+        result.snake_(self, alpha, beta_scale)?;
+        Ok(result)
+    }
+
     #[tracing::instrument(skip_all)]
     pub fn layer_norm(&self, weight: &Self, bias: &Self, eps: f32) -> Result<Self> {
         self.layer_norm_rm(weight, bias, eps, true)

--- a/xn-core/src/ops.rs
+++ b/xn-core/src/ops.rs
@@ -294,19 +294,18 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
     /// Kernel: (out_channels, in_channels/groups, kernel_size)
     /// Output: (batch, out_channels, out_length)
     #[tracing::instrument(skip_all)]
-    /// `conv1d` immediately followed by a per-channel snake activation
-    /// (`y = x + beta_scale[c] * sin(alpha[c] * x)^2`), asking the backend to
-    /// fold both the bias and the activation into the convolution epilogue.
-    /// Whatever the backend does not fuse is applied here, so the result is the
-    /// same as `conv1d(..).snake(alpha, beta_scale)` either way.
+    /// `conv1d` with an optional residual add and/or per-channel snake
+    /// activation folded into the convolution epilogue where the backend
+    /// supports it. Semantically `snake(conv1d(..) + residual)`; whatever is not
+    /// fused is applied here, so the result matches either way.
     #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip_all)]
-    pub fn conv1d_snake(
+    pub fn conv1d_fused(
         &self,
         kernel: &Self,
         bias: Option<&Self>,
-        alpha: &Self,
-        beta_scale: &Self,
+        snake: Option<(&Self, &Self)>,
+        residual: Option<&Self>,
         stride: usize,
         padding: usize,
         dilation: usize,
@@ -323,24 +322,24 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         let out_length = (length + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1;
         let mut result =
             unsafe { Tensor::alloc_uninit((batch, out_channels, out_length), self.device()) }?;
-        let (bias_applied, snake_applied) = result.conv1d_with_bias_snake_(
-            self,
-            kernel,
-            bias,
-            Some((alpha, beta_scale)),
-            stride,
-            padding,
-            dilation,
-            groups,
+        let fused = result.conv1d_fused_(
+            self, kernel, bias, snake, residual, stride, padding, dilation, groups,
         )?;
         if let Some(bias) = bias
-            && !bias_applied
+            && !fused.bias
         {
             let bias = bias.reshape((1, out_channels, 1))?;
             result = result.broadcast_add(&bias)?;
         }
-        if !snake_applied {
-            result = result.snake(alpha, beta_scale)?;
+        if let Some(residual) = residual
+            && !fused.residual
+        {
+            result = result.add(residual)?;
+        }
+        if let Some((alpha, beta)) = snake
+            && !fused.snake
+        {
+            result = result.snake(alpha, beta)?;
         }
         Ok(result)
     }

--- a/xn-core/src/ops.rs
+++ b/xn-core/src/ops.rs
@@ -294,6 +294,57 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
     /// Kernel: (out_channels, in_channels/groups, kernel_size)
     /// Output: (batch, out_channels, out_length)
     #[tracing::instrument(skip_all)]
+    /// `conv1d` immediately followed by a per-channel snake activation
+    /// (`y = x + beta_scale[c] * sin(alpha[c] * x)^2`), asking the backend to
+    /// fold both the bias and the activation into the convolution epilogue.
+    /// Whatever the backend does not fuse is applied here, so the result is the
+    /// same as `conv1d(..).snake(alpha, beta_scale)` either way.
+    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip_all)]
+    pub fn conv1d_snake(
+        &self,
+        kernel: &Self,
+        bias: Option<&Self>,
+        alpha: &Self,
+        beta_scale: &Self,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<Self> {
+        let (batch, in_channels, length) = self.dims3()?;
+        let (out_channels, kernel_in_channels, kernel_size) = kernel.dims3()?;
+        if kernel_in_channels != in_channels / groups {
+            crate::bail!(
+                "kernel in_channels/groups mismatch: expected {}, got {kernel_in_channels}",
+                in_channels / groups,
+            );
+        }
+        let out_length = (length + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1;
+        let mut result =
+            unsafe { Tensor::alloc_uninit((batch, out_channels, out_length), self.device()) }?;
+        let (bias_applied, snake_applied) = result.conv1d_with_bias_snake_(
+            self,
+            kernel,
+            bias,
+            Some((alpha, beta_scale)),
+            stride,
+            padding,
+            dilation,
+            groups,
+        )?;
+        if let Some(bias) = bias
+            && !bias_applied
+        {
+            let bias = bias.reshape((1, out_channels, 1))?;
+            result = result.broadcast_add(&bias)?;
+        }
+        if !snake_applied {
+            result = result.snake(alpha, beta_scale)?;
+        }
+        Ok(result)
+    }
+
     pub fn conv1d(
         &self,
         kernel: &Self,

--- a/xn-core/src/ops.rs
+++ b/xn-core/src/ops.rs
@@ -322,11 +322,6 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         // Compute output length
         let out_length = (length + 2 * padding - dilation * (kernel_size - 1) - 1) / stride + 1;
 
-        let mut result =
-            unsafe { Tensor::alloc_uninit((batch, out_channels, out_length), self.device()) }?;
-        result.conv1d_(self, kernel, stride, padding, dilation, groups)?;
-
-        // Add bias if provided
         if let Some(bias) = bias {
             let bias_dims = bias.dims();
             if bias_dims != [out_channels] {
@@ -335,6 +330,17 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
                     bias.shape()
                 );
             }
+        }
+
+        let mut result =
+            unsafe { Tensor::alloc_uninit((batch, out_channels, out_length), self.device()) }?;
+        let bias_applied =
+            result.conv1d_with_bias_(self, kernel, bias, stride, padding, dilation, groups)?;
+
+        // Add bias separately if the backend did not fuse it
+        if let Some(bias) = bias
+            && !bias_applied
+        {
             // Reshape bias to (1, out_channels, 1) for broadcasting
             let bias = bias.reshape((1, out_channels, 1))?;
             result = result.broadcast_add(&bias)?;
@@ -375,11 +381,6 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         // out_length = (length - 1) * stride - 2 * padding + kernel_size + output_padding
         let out_length = (length - 1) * stride + kernel_size + output_padding - 2 * padding;
 
-        let mut result =
-            unsafe { Tensor::alloc_uninit((batch, out_channels, out_length), self.device()) }?;
-        result.conv_transpose1d_(self, kernel, stride, padding, output_padding, groups)?;
-
-        // Add bias if provided
         if let Some(bias) = bias {
             let bias_dims = bias.dims();
             if bias_dims != [out_channels] {
@@ -388,6 +389,24 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
                     bias.shape()
                 );
             }
+        }
+
+        let mut result =
+            unsafe { Tensor::alloc_uninit((batch, out_channels, out_length), self.device()) }?;
+        let bias_applied = result.conv_transpose1d_with_bias_(
+            self,
+            kernel,
+            bias,
+            stride,
+            padding,
+            output_padding,
+            groups,
+        )?;
+
+        // Add bias separately if the backend did not fuse it
+        if let Some(bias) = bias
+            && !bias_applied
+        {
             // Reshape bias to (1, out_channels, 1) for broadcasting
             let bias = bias.reshape((1, out_channels, 1))?;
             result = result.broadcast_add(&bias)?;

--- a/xn-core/src/vulkan_backend/backend_impl.rs
+++ b/xn-core/src/vulkan_backend/backend_impl.rs
@@ -569,6 +569,18 @@ impl crate::Backend for Device {
         dst.device.dispatch(&format!("softmax_{dt}"), &[src.buffer, dst.buffer], &push, d as u32)
     }
 
+    fn snake<T: WithDTypeF>(
+        _dst: &mut Self::Storage<T>,
+        _src: &Self::Storage<T>,
+        _alpha: &Self::Storage<T>,
+        _beta_scale: &Self::Storage<T>,
+        _channels: usize,
+        _row_len: usize,
+        _numel: usize,
+    ) -> Result<()> {
+        crate::bail!("snake is not implemented for this backend")
+    }
+
     fn rms_norm<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/src/webgpu_backend/backend_impl.rs
+++ b/xn-core/src/webgpu_backend/backend_impl.rs
@@ -512,6 +512,18 @@ impl crate::Backend for Device {
         dst.device.dispatch(&format!("softmax_{dt}"), &[&src.buffer, &dst.buffer], &push, d as u32)
     }
 
+    fn snake<T: WithDTypeF>(
+        _dst: &mut Self::Storage<T>,
+        _src: &Self::Storage<T>,
+        _alpha: &Self::Storage<T>,
+        _beta_scale: &Self::Storage<T>,
+        _channels: usize,
+        _row_len: usize,
+        _numel: usize,
+    ) -> Result<()> {
+        crate::bail!("snake is not implemented for this backend")
+    }
+
     fn rms_norm<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
         src: &Self::Storage<T>,

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1831,3 +1831,44 @@ fn test_snake_cuda() -> Result<()> {
     let device = xn::cuda_backend::Device::new(0)?;
     test_snake_impl(&device)
 }
+
+// Conv bias fusion: conv with bias must match conv without bias + broadcast
+// add, on every backend (fused epilogue on cuda, fallback path elsewhere).
+fn test_conv_bias_fusion_impl<B: Backend>(device: &B) -> Result<()> {
+    let (b, c_in, c_out, l, k) = (2, 5, 7, 13, 3);
+    let xs: Vec<f32> =
+        (0..b * c_in * l).map(|i| ((i * 37 + 11) % 23) as f32 * 0.17 - 1.9).collect();
+    let w: Vec<f32> =
+        (0..c_out * c_in * k).map(|i| ((i * 29 + 5) % 19) as f32 * 0.11 - 1.0).collect();
+    let bias: Vec<f32> = (0..c_out).map(|i| i as f32 * 0.73 - 2.1).collect();
+
+    let xs: Tensor<f32, B> = Tensor::from_vec(xs, vec![b, c_in, l], device)?;
+    let w_t: Tensor<f32, B> = Tensor::from_vec(w.clone(), vec![c_out, c_in, k], device)?;
+    let bias_t: Tensor<f32, B> = Tensor::from_vec(bias, vec![c_out], device)?;
+
+    let fused = xs.conv1d(&w_t, Some(&bias_t), 1, 1, 1, 1)?;
+    let unfused =
+        xs.conv1d(&w_t, None, 1, 1, 1, 1)?.broadcast_add(&bias_t.reshape((1, c_out, 1))?)?;
+    assert_eq!(fused.to_vec()?, unfused.to_vec()?, "conv1d bias mismatch");
+
+    // conv_transpose1d: kernel layout (c_in, c_out, k), stride 2 upsampling
+    let wt: Tensor<f32, B> = Tensor::from_vec(w, vec![c_in, c_out, k], device)?;
+    let fused = xs.conv_transpose1d(&wt, Some(&bias_t), 2, 0, 0, 1)?;
+    let unfused = xs
+        .conv_transpose1d(&wt, None, 2, 0, 0, 1)?
+        .broadcast_add(&bias_t.reshape((1, c_out, 1))?)?;
+    assert_eq!(fused.to_vec()?, unfused.to_vec()?, "conv_transpose1d bias mismatch");
+    Ok(())
+}
+
+#[test]
+fn test_conv_bias_fusion_cpu() -> Result<()> {
+    test_conv_bias_fusion_impl(&xn::CPU)
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_conv_bias_fusion_cuda() -> Result<()> {
+    let device = xn::cuda_backend::Device::new(0)?;
+    test_conv_bias_fusion_impl(&device)
+}

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1834,6 +1834,43 @@ fn test_snake_cuda() -> Result<()> {
 
 // Conv bias fusion: conv with bias must match conv without bias + broadcast
 // add, on every backend (fused epilogue on cuda, fallback path elsewhere).
+fn test_conv_snake_fusion_impl<B: Backend>(device: &B) -> Result<()> {
+    let (b, c_in, c_out, l, k) = (2, 5, 7, 13, 3);
+    let xs: Vec<f32> = (0..b * c_in * l).map(|i| ((i * 31 + 7) % 19) as f32 * 0.21 - 1.7).collect();
+    let w: Vec<f32> =
+        (0..c_out * c_in * k).map(|i| ((i * 13 + 5) % 11) as f32 * 0.09 - 0.4).collect();
+    let bias: Vec<f32> = (0..c_out).map(|i| 0.3 - i as f32 * 0.11).collect();
+    let alpha: Vec<f32> = (0..c_out).map(|i| 0.4 + i as f32 * 0.7).collect();
+    let beta: Vec<f32> = (0..c_out).map(|i| 1.6 - i as f32 * 0.19).collect();
+
+    let xs_t: Tensor<f32, B> = Tensor::from_vec(xs, vec![b, c_in, l], device)?;
+    let w_t: Tensor<f32, B> = Tensor::from_vec(w, vec![c_out, c_in, k], device)?;
+    let bias_t: Tensor<f32, B> = Tensor::from_vec(bias, c_out, device)?;
+    let alpha_t: Tensor<f32, B> = Tensor::from_vec(alpha, vec![1, c_out, 1], device)?;
+    let beta_t: Tensor<f32, B> = Tensor::from_vec(beta, vec![1, c_out, 1], device)?;
+
+    // The fused epilogue must match conv1d followed by a separate snake.
+    let fused = xs_t.conv1d_snake(&w_t, Some(&bias_t), &alpha_t, &beta_t, 1, 0, 1, 1)?.to_vec()?;
+    let composed =
+        xs_t.conv1d(&w_t, Some(&bias_t), 1, 0, 1, 1)?.snake(&alpha_t, &beta_t)?.to_vec()?;
+    assert_eq!(fused.len(), composed.len());
+    for (i, (f, c)) in fused.iter().zip(composed.iter()).enumerate() {
+        assert!((f - c).abs() <= 1e-5 * c.abs().max(1.0), "idx {i}: fused {f} composed {c}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_conv_snake_fusion_cpu() -> Result<()> {
+    test_conv_snake_fusion_impl(&xn::CPU)
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_conv_snake_fusion_cuda() -> Result<()> {
+    test_conv_snake_fusion_impl(&xn::cuda_backend::Device::new(0)?)
+}
+
 fn test_conv_bias_fusion_impl<B: Backend>(device: &B) -> Result<()> {
     let (b, c_in, c_out, l, k) = (2, 5, 7, 13, 3);
     let xs: Vec<f32> =

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1787,3 +1787,47 @@ fn test_matmul_batched_strided_impl<B: Backend>(dev: &B) -> Result<()> {
     Ok(())
 }
 test_all_backends!(test_matmul_batched_strided, test_matmul_batched_strided_impl);
+
+// Fused snake activation: check against the composed op sequence it replaces
+// (broadcast_mul -> sin -> sqr -> broadcast_mul -> add) and a host reference.
+fn test_snake_impl<B: Backend>(device: &B) -> Result<()> {
+    let (b, c, l) = (2, 3, 17);
+    let xs: Vec<f32> = (0..b * c * l)
+        .map(|i| ((i as f32) * 0.37 - 10.0) * ((i % 7) as f32 * 0.21 + 0.1))
+        .collect();
+    let alpha: Vec<f32> = (0..c).map(|i| 0.5 + i as f32 * 0.8).collect();
+    let beta_scale: Vec<f32> = (0..c).map(|i| 1.7 - i as f32 * 0.4).collect();
+
+    let xs_t: Tensor<f32, B> = Tensor::from_vec(xs.clone(), vec![b, c, l], device)?;
+    let alpha_t: Tensor<f32, B> = Tensor::from_vec(alpha.clone(), vec![1, c, 1], device)?;
+    let beta_t: Tensor<f32, B> = Tensor::from_vec(beta_scale.clone(), vec![1, c, 1], device)?;
+
+    let fused = xs_t.snake(&alpha_t, &beta_t)?.to_vec()?;
+    let sin2 = xs_t.broadcast_mul(&alpha_t)?.sin()?.sqr()?;
+    let composed = xs_t.add(&sin2.broadcast_mul(&beta_t)?)?.to_vec()?;
+
+    for (i, (f, cm)) in fused.iter().zip(composed.iter()).enumerate() {
+        assert!((f - cm).abs() <= 1e-5 * cm.abs().max(1.0), "idx {i}: fused {f} composed {cm}");
+        let ch = (i / l) % c;
+        let x = xs[i];
+        let s = (alpha[ch] * x).sin();
+        let reference = x + beta_scale[ch] * s * s;
+        assert!(
+            (f - reference).abs() <= 1e-5 * reference.abs().max(1.0),
+            "idx {i}: fused {f} reference {reference}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_snake_cpu() -> Result<()> {
+    test_snake_impl(&xn::CPU)
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_snake_cuda() -> Result<()> {
+    let device = xn::cuda_backend::Device::new(0)?;
+    test_snake_impl(&device)
+}

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1850,12 +1850,37 @@ fn test_conv_snake_fusion_impl<B: Backend>(device: &B) -> Result<()> {
     let beta_t: Tensor<f32, B> = Tensor::from_vec(beta, vec![1, c_out, 1], device)?;
 
     // The fused epilogue must match conv1d followed by a separate snake.
-    let fused = xs_t.conv1d_snake(&w_t, Some(&bias_t), &alpha_t, &beta_t, 1, 0, 1, 1)?.to_vec()?;
+    let fused = xs_t
+        .conv1d_fused(&w_t, Some(&bias_t), Some((&alpha_t, &beta_t)), None, 1, 0, 1, 1)?
+        .to_vec()?;
     let composed =
         xs_t.conv1d(&w_t, Some(&bias_t), 1, 0, 1, 1)?.snake(&alpha_t, &beta_t)?.to_vec()?;
     assert_eq!(fused.len(), composed.len());
     for (i, (f, c)) in fused.iter().zip(composed.iter()).enumerate() {
         assert!((f - c).abs() <= 1e-5 * c.abs().max(1.0), "idx {i}: fused {f} composed {c}");
+    }
+
+    // The residual add fuses into the same epilogue, alone and with the snake.
+    let out_len = l - k + 1;
+    let res: Vec<f32> =
+        (0..b * c_out * out_len).map(|i| ((i * 17 + 3) % 13) as f32 * 0.31 - 1.1).collect();
+    let res_t: Tensor<f32, B> = Tensor::from_vec(res, vec![b, c_out, out_len], device)?;
+    let fused_res =
+        xs_t.conv1d_fused(&w_t, Some(&bias_t), None, Some(&res_t), 1, 0, 1, 1)?.to_vec()?;
+    let composed_res = xs_t.conv1d(&w_t, Some(&bias_t), 1, 0, 1, 1)?.add(&res_t)?.to_vec()?;
+    for (i, (f, c)) in fused_res.iter().zip(composed_res.iter()).enumerate() {
+        assert!((f - c).abs() <= 1e-5 * c.abs().max(1.0), "res idx {i}: {f} vs {c}");
+    }
+    let fused_both = xs_t
+        .conv1d_fused(&w_t, Some(&bias_t), Some((&alpha_t, &beta_t)), Some(&res_t), 1, 0, 1, 1)?
+        .to_vec()?;
+    let composed_both = xs_t
+        .conv1d(&w_t, Some(&bias_t), 1, 0, 1, 1)?
+        .add(&res_t)?
+        .snake(&alpha_t, &beta_t)?
+        .to_vec()?;
+    for (i, (f, c)) in fused_both.iter().zip(composed_both.iter()).enumerate() {
+        assert!((f - c).abs() <= 1e-5 * c.abs().max(1.0), "both idx {i}: {f} vs {c}");
     }
     Ok(())
 }


### PR DESCRIPTION
**Draft / not for merge as-is.** This is the full prototype stack from an
investigation into why xn's mimi decode step was 3.1× slower than an
XLA-compiled build of the same model. It takes batch 32 from **27.90 to
10.63 ms/step**, within **1.19×** of xla. Some commits are shippable, some are
benchmark scaffolding — the split is below. #57 is the clean, bit-identical
subset already up for review; this branch is the rest, kept together so the
measurements are reproducible.

All numbers: RTX 4080 SUPER (sm_89), CUDA 13.2, model `tts-af440bf5.1`
(48 kHz qwen mimi decoder), mimi decode step only, p50 over 200 steps.

## Result

| step | b16 | b32 | notes |
|---|---|---|---|
| xn 0.2.2 (shipped today) | 14.05 | 27.90 | |
| + fused snake activation | 11.28 | 21.98 | bit-identical¹ |
| + conv-bias epilogue | 10.27 | 19.92 | bit-exact |
| + CUDA-graph replay of the step | 7.23 | 13.50 | prototype only |
| + activation into state concatenation | 6.91 | 12.84 | bit-identical¹ |
| + residual add into epilogue | 6.79 | 12.53 | bit-identical¹ |
| + per-shape conv routing | **6.76** | **10.63** | numerics shift ~5e-5² |
| xla reference | 5.81 | 8.93 | |

¹ identical to each other; differs from the unfused chain by float
reassociation (`beta*s*s` vs `(s*s)*beta`), ~7e-5 relative.
² a conv-backend swap is not bit-identical, see below.

## What's in here, and what it's worth

**Shippable, no dependencies, bit-identical or bit-exact**

- `Add a fused snake activation kernel` + `Fuse the conv bias into the epilogue`
  — these two are #57. −5.9 and −2.1 ms at b32.
- `Fold a per-channel snake activation into the conv1d im2col epilogue` — the
  epilogue already owns the only write to the conv output, so an activation
  consuming that output rides along free. Catches 15 of 36 activations (those
  whose producer is a conv). −0.4 ms.
- `Add a snake activation that writes into a window of a longer destination`
  (`snake_offset`) — every streaming conv concatenates its carried state with
  the new input each step; that pass can absorb the activation feeding it.
  Sound because snake is elementwise, so `snake(cat(prev,x)) ==
  cat(snake(prev),snake(x))`, and zeros stay zeros so left-padding is safe.
  Catches the other 15 (those feeding a kernel-size-1 conv have no state, hence
  no concatenation, and vice versa — the two boundaries are complementary and a
  single conv can use both). −0.66 ms with the epilogue form.
- `Fold the residual add into the conv1d epilogue` — generalizes the contract to
  `conv1d_fused(bias, snake, residual)` reporting back a `ConvFused` struct. The
  resnet skip connection goes to the block's last conv. −0.31 ms.

**Shippable but needs a numerics check, and adds a libcudnn dependency**

- `Optional cuDNN path for f32 conv1d/conv_transpose1d` and
  `cudnn: route convolutions per shape` — the largest single win after the
  graph, −1.55 ms, but see the caveat below.

**Benchmark scaffolding, must not ship**

- `cuda: leak storage frees while a CUDA-graph capture is in flight` — required
  to capture the step at all (streaming conv states churn allocations, so
  pre-capture buffers get freed inside the capture, which is invalid). Leaking
  is the wrong fix; a production version defers frees to `capture_end`.
- `cudnn: ... XN_CUDNN_NOFUSE experiment gate` — kept only because its negative
  result is worth recording.

## Conclusions

**1. The launch-overhead problem is solved, and past xla.** Capturing the whole
decode step as a CUDA graph is worth −6.4 ms at b32 on its own. After it, xn's
wall clock equals its GPU time — zero idle — while xla still leaves ~10% of its
step idle. Productizing needs three things this branch hacks around: deferred
(not leaked) frees during capture, rope positions moved to a device buffer
(absolute positions never repeat, so the htod replay cache cannot serve them),
and a record pass covering the decoder transformer's 72-step scatter-index cycle.

**2. Hand-written fusion is additive and not capped — I was wrong to suggest
otherwise.** Four fused variants land 1.6 ms in total. The limit is coverage per
pattern, not achievable speed: each fusion recovers roughly one pass over the
tensor, and each producer shape needs its own variant. What xla does better here
is breadth (it fuses whatever chain it finds), not peak kernel speed.

**3. cuDNN is not uniformly better, and treating it as all-or-nothing cost
1.55 ms.** Per-launch measurement:
- Transposed convs: cuDNN's `ConvolutionBackwardData` engines cost 1.96 ms/step
  against **0.22 ms** for xn's own col2im+gemm. cuDNN is 9× worse.
- Forward convs: the kernel-size-7 convs' im2col is 2.6 of 2.98 ms — a 7× data
  expansion at 48 kHz — so implicit gemm wins clearly. The kernel-size-1 convs'
  im2col is ~0.2 ms (it is just a transpose) and routing them to cuDNN forfeits
  the fused epilogue for nothing.

  Hence `XN_CUDNN_FWD_ONLY` and `XN_CUDNN_MIN_K`. With them, **xn's conv engines
  cost 4.52 ms against xla's 5.40** — below xla, because xla sends everything
  through cuDNN including the transposed convs.

**4. xn and xla ask cuDNN for the same thing.** Verified by kernel identity in
both traces: same `sm80_xmma_fprop_implicit_gemm_tf32f32_*` engines, same
`scudnn_*_relu_*` for bias-fused convs, same cutlass tf32 dgrad. Both use NCW
layout and `DEFAULT_MATH` (so xn's default already matched; requesting
`TENSOR_OP_MATH` is worth only −0.18 ms), both fuse bias+activation, and both pay
the same ~50 NCHW↔NHWC converts per step — those converts are **not** xn
overhead, contrary to what I first reported. The one divergence is algorithm
selection: xla autotunes per-shape engine ids with tuning knobs; xn uses the
cuDNN v7 heuristic. I added measured autotuning over all 8 forward and 6
backward-data legacy algorithms and **it changed nothing** (15.99 → 15.97 ms) —
the heuristic already picks the same winners, and the tile-level knobs xla tunes
are only reachable through the cuDNN frontend API, which cudarc does not wrap.

**5. Numerics.** Every fusion here is bit-identical or bit-exact, checked with an
end-to-end audio digest rather than only unit tests, because a mis-wired
activation passes a kernel-level test. The conv *routing* is different: cuDNN's
implicit-gemm accumulation order shifts the digest by 3–7e-5 relative, and each
routing mix shifts it slightly differently. That wants a WER check before
shipping; the fusions do not.

**6. Two measurement mistakes I made, in case they bite someone else.**
- XLA runs part of its graph in CUDA command buffers. Profiled without
  `--cuda-graph-trace=node` it under-reports by **229 launches and 1.0 ms/step**
  — the whole mimi transformer, which XLA emits as Triton `gemm_fusion_dot`
  kernels. Caught by cross-checking XLA's own thunk sequence (372 thunks vs 191
  traced launches). Every xla figure here is node-traced.
- `xmma` and `cutlass` name both cuDNN conv engines and cuBLAS gemms, so keying
  a kernel classifier off those substrings silently books the transformer's
  matmuls as convolution time. Key off `fprop`/`dgrad`/`wgrad`/`scudnn` instead.

## What is left, and how to get it

Remaining 2.67 ms of GPU time (10.73 vs xla 8.06), each with its evidence:

| item | xn | xla | route |
|---|---|---|---|
| activations | 1.30 | — | 21 of 36 are standalone again: routing k>1 convs to cuDNN gave up their epilogue, so the activation feeding each k=1 conv lost its home. Fuse it into that conv's im2col — at k=1 each element is read once, so no redundant `sin`. ≈−0.45 |
| copies | 0.54 | — | state cats and narrow+contiguous state updates; fold the conv-transpose overlap-add into col2im, which also removes its copy. ≈−0.3 |
| adds | 0.29 | — | already fused |
| *(xla pointwise total)* | *2.13* | *1.07* | |
| transformer gemms | 0.85 | 0.41 | xla's Triton gemms absorb the surrounding bias/norm; needs cuBLASLt epilogues. ≈−0.4 |
| conv pipeline | 6.26 | 6.41 | at parity, nothing left |

That is ~9.5 ms from three more fusions, all following patterns already built
here. Beyond that the remaining ideas are the channels-last/pixel-shuffle
decoder rewrite (`aa01a6d` on the `snake-fused` branch, which turns causal
conv-transposes into forward convs and sidesteps dgrad entirely) and cuDNN
frontend-API bindings in cudarc.

## Reproducing

Companion gradium-serve branch: `mimi-fusion-prototype` (call sites, phase
timers, the `mimi_phase_bench` examples, and a `[patch.crates-io]` pointing at a
local xn checkout that must be dropped before merge).

```
MIMI_BENCH_B=32 XN_FUSED_SNAKE=1 XN_FUSED_SNAKE_CAT=1 \
XN_CUDNN=1 XN_CUDNN_FWD_ONLY=1 XN_CUDNN_MIN_K=2 \
MIMI_GRAPH=1 XN_GRAPH_FREEZE_ROPE_POS=1 \
cargo run -r -p xn-moshi --example mimi_phase_bench --features cuda
```

cuDNN needs `RUSTFLAGS="-L .../cudnn-dev"` to build and the cuDNN libs on
`LD_LIBRARY_PATH` to run. `MIMI_BENCH_CHECKSUM=1` prints the audio digest used
for the bit-identity checks. Graph arms are perf-only: frozen rope positions
make the audio wrong.

Full write-up with every profile and the per-launch breakdowns:
https://claude.ai/code/artifact/f02a912c-3503-437f-9d14-92a98df71101

## Self-review

- [x] Tests pass: full `tensor_tests` suite green with `--features cuda`
      (214 passed), including new snake, conv+snake and conv+residual fusion
      tests; conv tests also run green with `XN_CUDNN=1` and with
      `XN_CUDNN_NOFUSE=1`.
- [x] Numerics characterized per commit, with the one non-bit-identical change
      (conv routing) called out and quantified rather than glossed.
- [x] Every performance claim measured on this branch, node-traced, with the two
      measurement errors found and corrected in the write-up above.
- [x] Scope is honest: the commits that must not ship are named as such, and the
      clean subset is already separated into #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017phHCJvH9dxZFyV2Wv91BL
