### PR TITLE
Perf/cpu conv tr and softmax

### DIFF
--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -417,9 +417,10 @@ impl crate::Backend for crate::CpuDevice {
         if !use_parallelism(l) {
             dst[..l].copy_from_slice(&src[..l]);
         } else {
+            let chunk = elemwise_chunk(l);
             dst[..l]
-                .par_chunks_mut(ELEMWISE_CHUNK)
-                .zip(src[..l].par_chunks(ELEMWISE_CHUNK))
+                .par_chunks_mut(chunk)
+                .zip(src[..l].par_chunks(chunk))
                 .for_each(|(d, s)| d.copy_from_slice(s));
         }
         Ok(())
@@ -492,7 +493,7 @@ impl crate::Backend for crate::CpuDevice {
             }
         };
         if use_parallelism(len) {
-            dst[..len].par_chunks_mut(ELEMWISE_CHUNK).for_each(fill);
+            dst[..len].par_chunks_mut(elemwise_chunk(len)).for_each(fill);
         } else {
             fill(&mut dst[..len]);
         }
@@ -513,7 +514,7 @@ impl crate::Backend for crate::CpuDevice {
             }
         };
         if use_parallelism(len) {
-            dst[..len].par_chunks_mut(ELEMWISE_CHUNK).for_each(fill);
+            dst[..len].par_chunks_mut(elemwise_chunk(len)).for_each(fill);
         } else {
             fill(&mut dst[..len]);
         }
@@ -524,7 +525,7 @@ impl crate::Backend for crate::CpuDevice {
         if !use_parallelism(l) {
             dst[..l].fill(v);
         } else {
-            dst[..l].par_chunks_mut(ELEMWISE_CHUNK).for_each(|d| d.fill(v));
+            dst[..l].par_chunks_mut(elemwise_chunk(l)).for_each(|d| d.fill(v));
         }
         Ok(())
     }
@@ -1417,9 +1418,19 @@ fn reduce_arg<T: WithDType + Copy>(
 /// Below this many elements, elementwise ops run serially: the rayon fork/join overhead
 /// (~10us) dwarfs the work itself.
 const ELEMWISE_PAR_THRESHOLD: usize = 32 * 1024;
-/// Chunk size for parallel elementwise ops; large enough that the per-chunk dispatch cost is
-/// negligible and the inner loop auto-vectorizes.
-const ELEMWISE_CHUNK: usize = 64 * 1024;
+/// Floor on the chunk size for parallel elementwise ops: below this the per-chunk dispatch
+/// cost stops being negligible and the inner loop has too few iterations to auto-vectorize
+/// well.
+const ELEMWISE_MIN_CHUNK: usize = 4 * 1024;
+
+/// Chunk size for parallel elementwise ops. This has to be derived from the work and the pool
+/// size rather than being a fixed constant: a constant larger than ELEMWISE_PAR_THRESHOLD
+/// means every length between the threshold and that constant yields a single chunk, paying
+/// the fork/join cost for no parallelism at all.
+fn elemwise_chunk(len: usize) -> usize {
+    let threads = rayon::current_num_threads().max(1);
+    len.div_ceil(threads).max(ELEMWISE_MIN_CHUNK)
+}
 
 /// Apply a binary operation in-place: dst[i] = op(dst[i], src[i])
 #[inline(always)]
@@ -1432,7 +1443,8 @@ where
             f(d, *s);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
+        let chunk = elemwise_chunk(dst.len());
+        dst.par_chunks_mut(chunk).zip(src.par_chunks(chunk)).for_each(
             |(dst, src)| {
                 for (d, s) in dst.iter_mut().zip(src) {
                     f(d, *s);
@@ -1453,7 +1465,7 @@ where
             f(d);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).for_each(|dst| {
+        dst.par_chunks_mut(elemwise_chunk(dst.len())).for_each(|dst| {
             for d in dst.iter_mut() {
                 f(d);
             }
@@ -1472,7 +1484,8 @@ where
             *d = f(*s);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
+        let chunk = elemwise_chunk(dst.len());
+        dst.par_chunks_mut(chunk).zip(src.par_chunks(chunk)).for_each(
             |(dst, src)| {
                 for (d, s) in dst.iter_mut().zip(src) {
                     *d = f(*s);
@@ -1493,8 +1506,9 @@ where
             *d = f(*l, *r);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK)
-            .zip(lhs.par_chunks(ELEMWISE_CHUNK).zip(rhs.par_chunks(ELEMWISE_CHUNK)))
+        let chunk = elemwise_chunk(dst.len());
+        dst.par_chunks_mut(chunk)
+            .zip(lhs.par_chunks(chunk).zip(rhs.par_chunks(chunk)))
             .for_each(|(dst, (lhs, rhs))| {
                 for ((d, l), r) in dst.iter_mut().zip(lhs).zip(rhs) {
                     *d = f(*l, *r);

--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -922,7 +922,10 @@ impl crate::Backend for crate::CpuDevice {
     ) -> Result<()> {
         let src = &src[..d * dim_m1];
         let dst = &mut dst[..d * dim_m1];
-        src.par_chunks(dim_m1).zip(dst.par_chunks_mut(dim_m1)).for_each(|(src, dst)| {
+        // Rows are independent, so this is gated the same way as the elementwise ops: during
+        // autoregressive decode a row is a single short attention vector, and the fork/join
+        // cost dominates the handful of exps it saves.
+        let softmax_row = |src: &[T], dst: &mut [T]| {
             let mut max = T::neg_infinity();
             for &v in src.iter() {
                 max = T::max(v, max)
@@ -934,7 +937,14 @@ impl crate::Backend for crate::CpuDevice {
             for d in dst.iter_mut() {
                 *d = T::from_f32(d.to_f32() / sum_exp)
             }
-        });
+        };
+        if use_parallelism(d * dim_m1) {
+            src.par_chunks(dim_m1)
+                .zip(dst.par_chunks_mut(dim_m1))
+                .for_each(|(s, d)| softmax_row(s, d));
+        } else {
+            src.chunks(dim_m1).zip(dst.chunks_mut(dim_m1)).for_each(|(s, d)| softmax_row(s, d));
+        }
         Ok(())
     }
 
@@ -1700,52 +1710,59 @@ fn conv_transpose1d_direct<T: WithDTypeF>(
         }
     }
 
-    // Process each kernel offset
-    for k_offset in 0..kernel_size {
-        // Parallelize over output channels
-        (0..out_channels).into_par_iter().for_each(|out_c| {
-            let g = out_c / out_c_per_group;
-            let oc_in_group = out_c % out_c_per_group;
-            let in_c_start = g * in_c_per_group;
+    // Each (b, out_c) pair owns a contiguous `out_length` slice of dst, so the op splits over
+    // those slices instead of over channels once per kernel offset. That means one fork/join
+    // for the whole call rather than `kernel_size` of them, safe mutable access instead of raw
+    // pointers, and no per-(channel, offset) weight buffer. Keeping k_offset outermost within
+    // a slice preserves the original accumulation order into dst, so results are unchanged.
+    let src_reordered = src_reordered.as_slice();
+    let accumulate = |bc: usize, dst_row: &mut [T]| {
+        let b = bc / out_channels;
+        let out_c = bc % out_channels;
+        let g = out_c / out_c_per_group;
+        let oc_in_group = out_c % out_c_per_group;
+        let in_c_start = g * in_c_per_group;
+        let src_row = &src_reordered[b * length * in_channels..(b + 1) * length * in_channels];
+        // Kernel layout: [in_channels, out_channels/groups, kernel_size]
+        let k_base = in_c_start * out_c_per_group * kernel_size + oc_in_group * kernel_size;
 
-            // Gather kernel weights for this output channel and kernel offset
-            // Kernel layout: [in_channels, out_channels/groups, kernel_size]
-            let k_cont: Vec<T> = (0..in_c_per_group)
-                .map(|ic| {
-                    let in_c = in_c_start + ic;
-                    let k_idx =
-                        in_c * out_c_per_group * kernel_size + oc_in_group * kernel_size + k_offset;
-                    kernel[k_idx]
-                })
-                .collect();
-
-            for b in 0..batch {
+        if in_c_per_group == 1 {
+            // Depthwise: the dot product over input channels collapses to a single multiply,
+            // and this channel's kernel taps are contiguous.
+            let w = &kernel[k_base..k_base + kernel_size];
+            for (k_offset, &wk) in w.iter().enumerate() {
                 for il in 0..length {
                     let out_pos_raw = il * stride + k_offset;
-
-                    // Check padding bounds
                     if out_pos_raw < padding || out_pos_raw >= out_length + padding {
                         continue;
                     }
-                    let out_pos = out_pos_raw - padding;
-
-                    // Compute dot product over input channels
-                    let src_base = b * length * in_channels + il * in_channels + in_c_start;
-                    let mut d = T::zero();
-                    for ic in 0..in_c_per_group {
-                        d += src_reordered[src_base + ic] * k_cont[ic];
-                    }
-
-                    // Accumulate into output
-                    // Safety: each out_c is processed by a different thread, so no races
-                    let dst_idx = b * out_channels * out_length + out_c * out_length + out_pos;
-                    unsafe {
-                        let ptr = dst.as_ptr().add(dst_idx) as *mut T;
-                        *ptr += d;
-                    }
+                    dst_row[out_pos_raw - padding] += src_row[il * in_channels + in_c_start] * wk;
                 }
             }
-        });
+        } else {
+            for k_offset in 0..kernel_size {
+                for il in 0..length {
+                    let out_pos_raw = il * stride + k_offset;
+                    if out_pos_raw < padding || out_pos_raw >= out_length + padding {
+                        continue;
+                    }
+                    let src_base = il * in_channels + in_c_start;
+                    let mut acc = T::zero();
+                    for ic in 0..in_c_per_group {
+                        let k_idx = k_base + ic * out_c_per_group * kernel_size + k_offset;
+                        acc += src_row[src_base + ic] * kernel[k_idx];
+                    }
+                    dst_row[out_pos_raw - padding] += acc;
+                }
+            }
+        }
+    };
+
+    let dst = &mut dst[..batch * out_channels * out_length];
+    if use_parallelism(batch * out_channels * kernel_size * length) {
+        dst.par_chunks_mut(out_length).enumerate().for_each(|(bc, d)| accumulate(bc, d));
+    } else {
+        dst.chunks_mut(out_length).enumerate().for_each(|(bc, d)| accumulate(bc, d));
     }
     Ok(())
 }

--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -417,10 +417,9 @@ impl crate::Backend for crate::CpuDevice {
         if !use_parallelism(l) {
             dst[..l].copy_from_slice(&src[..l]);
         } else {
-            let chunk = elemwise_chunk(l);
             dst[..l]
-                .par_chunks_mut(chunk)
-                .zip(src[..l].par_chunks(chunk))
+                .par_chunks_mut(ELEMWISE_CHUNK)
+                .zip(src[..l].par_chunks(ELEMWISE_CHUNK))
                 .for_each(|(d, s)| d.copy_from_slice(s));
         }
         Ok(())
@@ -493,7 +492,7 @@ impl crate::Backend for crate::CpuDevice {
             }
         };
         if use_parallelism(len) {
-            dst[..len].par_chunks_mut(elemwise_chunk(len)).for_each(fill);
+            dst[..len].par_chunks_mut(ELEMWISE_CHUNK).for_each(fill);
         } else {
             fill(&mut dst[..len]);
         }
@@ -514,7 +513,7 @@ impl crate::Backend for crate::CpuDevice {
             }
         };
         if use_parallelism(len) {
-            dst[..len].par_chunks_mut(elemwise_chunk(len)).for_each(fill);
+            dst[..len].par_chunks_mut(ELEMWISE_CHUNK).for_each(fill);
         } else {
             fill(&mut dst[..len]);
         }
@@ -525,7 +524,7 @@ impl crate::Backend for crate::CpuDevice {
         if !use_parallelism(l) {
             dst[..l].fill(v);
         } else {
-            dst[..l].par_chunks_mut(elemwise_chunk(l)).for_each(|d| d.fill(v));
+            dst[..l].par_chunks_mut(ELEMWISE_CHUNK).for_each(|d| d.fill(v));
         }
         Ok(())
     }
@@ -1418,19 +1417,9 @@ fn reduce_arg<T: WithDType + Copy>(
 /// Below this many elements, elementwise ops run serially: the rayon fork/join overhead
 /// (~10us) dwarfs the work itself.
 const ELEMWISE_PAR_THRESHOLD: usize = 32 * 1024;
-/// Floor on the chunk size for parallel elementwise ops: below this the per-chunk dispatch
-/// cost stops being negligible and the inner loop has too few iterations to auto-vectorize
-/// well.
-const ELEMWISE_MIN_CHUNK: usize = 4 * 1024;
-
-/// Chunk size for parallel elementwise ops. This has to be derived from the work and the pool
-/// size rather than being a fixed constant: a constant larger than ELEMWISE_PAR_THRESHOLD
-/// means every length between the threshold and that constant yields a single chunk, paying
-/// the fork/join cost for no parallelism at all.
-fn elemwise_chunk(len: usize) -> usize {
-    let threads = rayon::current_num_threads().max(1);
-    len.div_ceil(threads).max(ELEMWISE_MIN_CHUNK)
-}
+/// Chunk size for parallel elementwise ops; large enough that the per-chunk dispatch cost is
+/// negligible and the inner loop auto-vectorizes.
+const ELEMWISE_CHUNK: usize = 64 * 1024;
 
 /// Apply a binary operation in-place: dst[i] = op(dst[i], src[i])
 #[inline(always)]
@@ -1443,8 +1432,7 @@ where
             f(d, *s);
         }
     } else {
-        let chunk = elemwise_chunk(dst.len());
-        dst.par_chunks_mut(chunk).zip(src.par_chunks(chunk)).for_each(
+        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
             |(dst, src)| {
                 for (d, s) in dst.iter_mut().zip(src) {
                     f(d, *s);
@@ -1465,7 +1453,7 @@ where
             f(d);
         }
     } else {
-        dst.par_chunks_mut(elemwise_chunk(dst.len())).for_each(|dst| {
+        dst.par_chunks_mut(ELEMWISE_CHUNK).for_each(|dst| {
             for d in dst.iter_mut() {
                 f(d);
             }
@@ -1484,8 +1472,7 @@ where
             *d = f(*s);
         }
     } else {
-        let chunk = elemwise_chunk(dst.len());
-        dst.par_chunks_mut(chunk).zip(src.par_chunks(chunk)).for_each(
+        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
             |(dst, src)| {
                 for (d, s) in dst.iter_mut().zip(src) {
                     *d = f(*s);
@@ -1506,9 +1493,8 @@ where
             *d = f(*l, *r);
         }
     } else {
-        let chunk = elemwise_chunk(dst.len());
-        dst.par_chunks_mut(chunk)
-            .zip(lhs.par_chunks(chunk).zip(rhs.par_chunks(chunk)))
+        dst.par_chunks_mut(ELEMWISE_CHUNK)
+            .zip(lhs.par_chunks(ELEMWISE_CHUNK).zip(rhs.par_chunks(ELEMWISE_CHUNK)))
             .for_each(|(dst, (lhs, rhs))| {
                 for ((d, l), r) in dst.iter_mut().zip(lhs).zip(rhs) {
                     *d = f(*l, *r);
@@ -1726,9 +1712,9 @@ fn conv_transpose1d_direct<T: WithDTypeF>(
 
     // Each (b, out_c) pair owns a contiguous `out_length` slice of dst, so the op splits over
     // those slices instead of over channels once per kernel offset. That means one fork/join
-    // for the whole call rather than `kernel_size` of them, safe mutable access instead of raw
-    // pointers, and no per-(channel, offset) weight buffer. Keeping k_offset outermost within
-    // a slice preserves the original accumulation order into dst, so results are unchanged.
+    // for the whole call rather than `kernel_size` of them, and safe mutable access instead of
+    // raw pointers. Keeping k_offset outermost within a slice preserves the original
+    // accumulation order into dst, so results are unchanged.
     let src_reordered = src_reordered.as_slice();
     let accumulate = |bc: usize, dst_row: &mut [T]| {
         let b = bc / out_channels;
@@ -1754,7 +1740,16 @@ fn conv_transpose1d_direct<T: WithDTypeF>(
                 }
             }
         } else {
+            // This channel's taps for a given k_offset sit `out_c_per_group * kernel_size`
+            // apart in `kernel`, so gather them once per offset rather than reading them
+            // strided inside the `il` loop: the dot product below then walks two contiguous
+            // buffers and vectorizes. The gather costs one `in_c_per_group` copy per
+            // (slice, offset), which is `length` times less work than the loop it feeds.
+            let mut k_cont = vec![T::zero(); in_c_per_group];
             for k_offset in 0..kernel_size {
+                for (ic, kc) in k_cont.iter_mut().enumerate() {
+                    *kc = kernel[k_base + ic * out_c_per_group * kernel_size + k_offset];
+                }
                 for il in 0..length {
                     let out_pos_raw = il * stride + k_offset;
                     if out_pos_raw < padding || out_pos_raw >= out_length + padding {
@@ -1762,9 +1757,8 @@ fn conv_transpose1d_direct<T: WithDTypeF>(
                     }
                     let src_base = il * in_channels + in_c_start;
                     let mut acc = T::zero();
-                    for ic in 0..in_c_per_group {
-                        let k_idx = k_base + ic * out_c_per_group * kernel_size + k_offset;
-                        acc += src_row[src_base + ic] * kernel[k_idx];
+                    for (ic, &kc) in k_cont.iter().enumerate() {
+                        acc += src_row[src_base + ic] * kc;
                     }
                     dst_row[out_pos_raw - padding] += acc;
                 }

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1009,6 +1009,130 @@ test_all_backends!(
     test_conv_transpose1d_batch_with_bias_impl
 );
 
+// -----------------------------------------------------------------------------
+// conv_transpose1d fallback path (cpu)
+//
+// The col2im fast path only applies when groups == 1 && padding == 0 &&
+// output_padding == 0; anything else goes through conv_transpose1d_direct. The tests above
+// all satisfy the fast-path condition, so these cover the fallback by equivalence against
+// the fast path.
+// -----------------------------------------------------------------------------
+
+/// Grouped conv_transpose1d equals per-group conv_transpose1d (groups=1) concatenated along
+/// the channel axis. The reference side takes the well-covered col2im path.
+fn check_grouped_matches_per_group(
+    batch: usize,
+    in_channels: usize,
+    out_c_per_group: usize,
+    length: usize,
+    kernel_size: usize,
+    stride: usize,
+    groups: usize,
+) -> Result<()> {
+    let dev = &xn::CPU;
+    let in_c_per_group = in_channels / groups;
+    let n_in = batch * in_channels * length;
+    let n_k = in_channels * out_c_per_group * kernel_size;
+    // Deterministic, non-symmetric values so channel/offset mix-ups actually show up.
+    let input: Tensor<f32, _> =
+        Tensor::from_vec((0..n_in).map(|i| (i % 7) as f32 - 3.).collect(), (batch, in_channels, length), dev)?;
+    let kernel: Tensor<f32, _> = Tensor::from_vec(
+        (0..n_k).map(|i| ((i % 5) as f32 - 2.) * 0.5).collect(),
+        (in_channels, out_c_per_group, kernel_size),
+        dev,
+    )?;
+
+    let got = input.conv_transpose1d(&kernel, None, stride, 0, 0, groups)?;
+
+    let mut parts = Vec::new();
+    for g in 0..groups {
+        let ic0 = g * in_c_per_group;
+        let sub_in = input.narrow(1, ic0..ic0 + in_c_per_group)?.contiguous()?;
+        let sub_k = kernel.narrow(0, ic0..ic0 + in_c_per_group)?.contiguous()?;
+        parts.push(sub_in.conv_transpose1d(&sub_k, None, stride, 0, 0, 1)?);
+    }
+    let refs: Vec<&Tensor<f32, _>> = parts.iter().collect();
+    let want = Tensor::cat(&refs, 1)?;
+
+    assert_eq!(got.dims(), want.dims(), "shape mismatch");
+    let (g, w) = (got.to_vec()?, want.to_vec()?);
+    for (i, (a, b)) in g.iter().zip(w.iter()).enumerate() {
+        assert!((a - b).abs() < 1e-4, "index {i}: got {a}, want {b}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_conv_transpose1d_depthwise_cpu() -> Result<()> {
+    // groups == in_channels == out_channels: the depthwise branch.
+    check_grouped_matches_per_group(1, 8, 1, 5, 4, 2, 8)?;
+    check_grouped_matches_per_group(2, 6, 1, 4, 6, 3, 6)?;
+    // Shaped like mimi's frame-rate adapter: kernel_size == 2 * stride, depthwise.
+    check_grouped_matches_per_group(1, 16, 1, 3, 8, 4, 16)
+}
+
+#[test]
+fn test_conv_transpose1d_grouped_cpu() -> Result<()> {
+    // 1 < groups < in_channels, so in_c_per_group > 1 (the general fallback branch).
+    check_grouped_matches_per_group(1, 8, 2, 5, 3, 1, 2)?;
+    check_grouped_matches_per_group(2, 12, 3, 4, 4, 2, 4)?;
+    // out_c_per_group > 1 together with in_c_per_group == 1 exercises the depthwise branch's
+    // kernel indexing without groups == out_channels.
+    check_grouped_matches_per_group(1, 4, 3, 4, 3, 2, 4)
+}
+
+#[test]
+fn test_conv_transpose1d_padding_crops_cpu() -> Result<()> {
+    // padding p on a transposed conv drops p elements from each end of the output.
+    let dev = &xn::CPU;
+    let input: Tensor<f32, _> =
+        Tensor::from_vec((0..12).map(|i| (i % 5) as f32 - 2.).collect(), (1, 3, 4), dev)?;
+    let kernel: Tensor<f32, _> =
+        Tensor::from_vec((0..18).map(|i| (i % 4) as f32 - 1.).collect(), (3, 2, 3), dev)?;
+
+    let unpadded = input.conv_transpose1d(&kernel, None, 2, 0, 0, 1)?;
+    let full_len = unpadded.dims()[2];
+    for p in 1..=2 {
+        let padded = input.conv_transpose1d(&kernel, None, 2, p, 0, 1)?;
+        assert_eq!(padded.dims(), &[1, 2, full_len - 2 * p], "padding {p} shape");
+        let want = unpadded.narrow(2, p..full_len - p)?.contiguous()?.to_vec()?;
+        let got = padded.to_vec()?;
+        for (i, (a, b)) in got.iter().zip(want.iter()).enumerate() {
+            assert!((a - b).abs() < 1e-4, "padding {p} index {i}: got {a}, want {b}");
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_conv_transpose1d_output_padding_appends_zeros_cpu() -> Result<()> {
+    // output_padding only extends the output; the extra tail positions receive no
+    // contributions and stay zero.
+    let dev = &xn::CPU;
+    let input: Tensor<f32, _> =
+        Tensor::from_vec((0..8).map(|i| (i % 3) as f32 - 1.).collect(), (1, 2, 4), dev)?;
+    let kernel: Tensor<f32, _> =
+        Tensor::from_vec((0..8).map(|i| (i % 3) as f32).collect(), (2, 2, 2), dev)?;
+
+    let base = input.conv_transpose1d(&kernel, None, 2, 0, 0, 1)?;
+    let base_len = base.dims()[2];
+    let base_v = base.to_vec()?;
+    let q = 3;
+    let extended = input.conv_transpose1d(&kernel, None, 2, 0, q, 1)?;
+    assert_eq!(extended.dims(), &[1, 2, base_len + q]);
+    let ext_v = extended.to_vec()?;
+    for c in 0..2 {
+        for i in 0..base_len {
+            let (a, b) = (ext_v[c * (base_len + q) + i], base_v[c * base_len + i]);
+            assert!((a - b).abs() < 1e-4, "ch {c} index {i}: got {a}, want {b}");
+        }
+        for i in base_len..base_len + q {
+            assert_eq!(ext_v[c * (base_len + q) + i], 0., "ch {c} tail index {i} not zero");
+        }
+    }
+    Ok(())
+}
+
 // =============================================================================
 // Pad with same tests
 // =============================================================================

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1034,8 +1034,11 @@ fn check_grouped_matches_per_group(
     let n_in = batch * in_channels * length;
     let n_k = in_channels * out_c_per_group * kernel_size;
     // Deterministic, non-symmetric values so channel/offset mix-ups actually show up.
-    let input: Tensor<f32, _> =
-        Tensor::from_vec((0..n_in).map(|i| (i % 7) as f32 - 3.).collect(), (batch, in_channels, length), dev)?;
+    let input: Tensor<f32, _> = Tensor::from_vec(
+        (0..n_in).map(|i| (i % 7) as f32 - 3.).collect(),
+        (batch, in_channels, length),
+        dev,
+    )?;
     let kernel: Tensor<f32, _> = Tensor::from_vec(
         (0..n_k).map(|i| ((i % 5) as f32 - 2.) * 0.5).collect(),
         (in_channels, out_c_per_group, kernel_size),


### PR DESCRIPTION
# CPU backend: gate softmax parallelism and restructure conv_transpose1d's fallback path

## Summary

Two independent changes, both aimed at the small-tensor regime that dominates autoregressive
decode, where a rayon fork/join (~20us here) can cost more than the op itself.

**1. `softmax` is gated by `use_parallelism`.** Rows were unconditionally dispatched with
`par_chunks`. During decode a row is one short attention vector, so the fork/join dwarfed the
handful of `exp`s it saved. This is the same gate the rest of the file already applies; above the
threshold the code path is unchanged.

**2. `conv_transpose1d_direct` splits over `(batch, out_channel)` output slices** instead of over
output channels once per kernel offset. Each `(b, out_c)` pair owns a contiguous `out_length`
slice of `dst`, which gives:

- one fork/join per call instead of `kernel_size` of them,
- safe `&mut [T]` slices instead of `unsafe` raw-pointer accumulation into `dst`,
- a depthwise (`in_c_per_group == 1`) branch where the dot product over input channels collapses
  to a single multiply against contiguous kernel taps,
- the per-`(slice, k_offset)` `k_cont` gather kept for the general branch — a channel's taps sit
  `out_c_per_group * kernel_size` apart, so gathering them once per offset keeps the inner dot
  product walking two contiguous buffers instead of reading `kernel` strided `length` times.

`k_offset` stays outermost within a slice, so the accumulation order into `dst` is unchanged and
results are bit-identical.

This is the fallback path: col2im handles `groups == 1 && padding == 0 && output_padding == 0`,
everything else lands here — so every grouped, depthwise, or padded transposed conv.

**Tests.** Four new CPU tests cover that fallback path, which previously had **no** coverage —
every existing `conv_transpose1d` test satisfied the col2im fast-path condition. They pin the
fallback by equivalence against the well-covered fast path: grouped equals per-group concatenated
along the channel axis, padding crops the output symmetrically, and `output_padding` only appends
zeros. Full workspace suite: 15 test binaries, 0 failures (154 tests in `xn`);
`cargo clippy --all-targets` clean.

## Benchmarks

Apple M5 (10 cores), `--release`, f32, 10 rayon threads. us/iter, median of 5 alternating runs,
lower is better.

### conv_transpose1d — direct/fallback path

| case | `main` | **this PR** | speedup |
|---|---:|---:|---:|
| stream, depthwise `c=512 l=1 k=12 s=6 g=512` | 369.01 | **8.11** | **45.5x** |
| depthwise `c=512 l=16 k=12 s=6 g=512` | 455.24 | **54.50** | **8.4x** |
| depthwise `c=128 l=480 k=8 s=4 g=128` | 442.72 | **193.27** | **2.3x** |
| depthwise `c=64 l=1920 k=8 s=4 g=64` | 599.29 | **317.64** | **1.9x** |
| grouped `c=256 l=96 k=10 s=5 g=4` | 1396.19 | **642.25** | **2.2x** |
| grouped `c=64 l=480 k=8 s=4 g=8` | 449.57 | **245.22** | **1.8x** |
| padded `g=1 c=512 l=64 k=12 s=6 p=3` | 8953.00 | **6067.87** | **1.5x** |
| padded `g=1 c=128 l=480 k=8 s=4 p=2` | 2718.76 | **1385.90** | **2.0x** |

A single-frame streaming step goes from 369us to 8.1us: `main` paid 12 fork/joins — one per kernel
offset — to do ~6K MACs. The depthwise branch accounts for most of the rest; the padded `g=1`
cases gain purely from the one-fork/join restructure, since they keep the gathered inner loop.

### softmax

| case | `main` | **this PR** | speedup |
|---|---:|---:|---:|
| decode `d=32 dim=64` (2K elems) | 26.19 | **3.21** | **8.2x** |
| decode `d=32 dim=256` (8K elems) | 27.90 | **14.49** | **1.9x** |
| decode `d=8 dim=1024` (8K elems) | 24.50 | **14.59** | **1.7x** |
| prefill `d=32 dim=2048` (64K elems) | 41.48 | 41.41 | 1.00x |
| prefill `d=256 dim=4096` (1M elems) | 320.80 | 321.34 | 1.00x |

The last two rows are the check that nothing changed above the threshold.

## Notes

- Untuned thresholds elsewhere: the fixed 32K `ELEMWISE_PAR_THRESHOLD` is too low for
  bandwidth-bound ops: `copy_` at 128K measures 23.6us parallel vs 5.8us serial on this machine.
