### PR TITLE
Perf/ops chunk size parallel

### DIFF
--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -417,9 +417,10 @@ impl crate::Backend for crate::CpuDevice {
         if !use_parallelism(l) {
             dst[..l].copy_from_slice(&src[..l]);
         } else {
+            let chunk = elemwise_chunk(l);
             dst[..l]
-                .par_chunks_mut(ELEMWISE_CHUNK)
-                .zip(src[..l].par_chunks(ELEMWISE_CHUNK))
+                .par_chunks_mut(chunk)
+                .zip(src[..l].par_chunks(chunk))
                 .for_each(|(d, s)| d.copy_from_slice(s));
         }
         Ok(())
@@ -492,7 +493,7 @@ impl crate::Backend for crate::CpuDevice {
             }
         };
         if use_parallelism(len) {
-            dst[..len].par_chunks_mut(ELEMWISE_CHUNK).for_each(fill);
+            dst[..len].par_chunks_mut(elemwise_chunk(len)).for_each(fill);
         } else {
             fill(&mut dst[..len]);
         }
@@ -513,7 +514,7 @@ impl crate::Backend for crate::CpuDevice {
             }
         };
         if use_parallelism(len) {
-            dst[..len].par_chunks_mut(ELEMWISE_CHUNK).for_each(fill);
+            dst[..len].par_chunks_mut(elemwise_chunk(len)).for_each(fill);
         } else {
             fill(&mut dst[..len]);
         }
@@ -524,7 +525,7 @@ impl crate::Backend for crate::CpuDevice {
         if !use_parallelism(l) {
             dst[..l].fill(v);
         } else {
-            dst[..l].par_chunks_mut(ELEMWISE_CHUNK).for_each(|d| d.fill(v));
+            dst[..l].par_chunks_mut(elemwise_chunk(l)).for_each(|d| d.fill(v));
         }
         Ok(())
     }
@@ -1417,9 +1418,19 @@ fn reduce_arg<T: WithDType + Copy>(
 /// Below this many elements, elementwise ops run serially: the rayon fork/join overhead
 /// (~10us) dwarfs the work itself.
 const ELEMWISE_PAR_THRESHOLD: usize = 32 * 1024;
-/// Chunk size for parallel elementwise ops; large enough that the per-chunk dispatch cost is
-/// negligible and the inner loop auto-vectorizes.
-const ELEMWISE_CHUNK: usize = 64 * 1024;
+/// Floor on the chunk size for parallel elementwise ops: below this the per-chunk dispatch
+/// cost stops being negligible and the inner loop has too few iterations to auto-vectorize
+/// well.
+const ELEMWISE_MIN_CHUNK: usize = 4 * 1024;
+
+/// Chunk size for parallel elementwise ops. This has to be derived from the work and the pool
+/// size rather than being a fixed constant: a constant larger than ELEMWISE_PAR_THRESHOLD
+/// means every length between the threshold and that constant yields a single chunk, paying
+/// the fork/join cost for no parallelism at all.
+fn elemwise_chunk(len: usize) -> usize {
+    let threads = rayon::current_num_threads().max(1);
+    len.div_ceil(threads).max(ELEMWISE_MIN_CHUNK)
+}
 
 /// Apply a binary operation in-place: dst[i] = op(dst[i], src[i])
 #[inline(always)]
@@ -1432,7 +1443,8 @@ where
             f(d, *s);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
+        let chunk = elemwise_chunk(dst.len());
+        dst.par_chunks_mut(chunk).zip(src.par_chunks(chunk)).for_each(
             |(dst, src)| {
                 for (d, s) in dst.iter_mut().zip(src) {
                     f(d, *s);
@@ -1453,7 +1465,7 @@ where
             f(d);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).for_each(|dst| {
+        dst.par_chunks_mut(elemwise_chunk(dst.len())).for_each(|dst| {
             for d in dst.iter_mut() {
                 f(d);
             }
@@ -1472,7 +1484,8 @@ where
             *d = f(*s);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
+        let chunk = elemwise_chunk(dst.len());
+        dst.par_chunks_mut(chunk).zip(src.par_chunks(chunk)).for_each(
             |(dst, src)| {
                 for (d, s) in dst.iter_mut().zip(src) {
                     *d = f(*s);
@@ -1493,8 +1506,9 @@ where
             *d = f(*l, *r);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK)
-            .zip(lhs.par_chunks(ELEMWISE_CHUNK).zip(rhs.par_chunks(ELEMWISE_CHUNK)))
+        let chunk = elemwise_chunk(dst.len());
+        dst.par_chunks_mut(chunk)
+            .zip(lhs.par_chunks(chunk).zip(rhs.par_chunks(chunk)))
             .for_each(|(dst, (lhs, rhs))| {
                 for ((d, l), r) in dst.iter_mut().zip(lhs).zip(rhs) {
                     *d = f(*l, *r);

--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -173,38 +173,41 @@ impl crate::Backend for crate::CpuDevice {
         len: usize,
         op: UnaryOp,
     ) -> Result<()> {
+        let chunk = unary_chunk(op, len);
         match op {
-            UnaryOp::Cos => apply_inplace_unary(&mut dst[..len], |v| *v = v.cos()),
-            UnaryOp::Sin => apply_inplace_unary(&mut dst[..len], |v| *v = v.sin()),
-            UnaryOp::Exp => apply_inplace_unary(&mut dst[..len], |v| *v = v.exp()),
-            UnaryOp::Log => apply_inplace_unary(&mut dst[..len], |v| *v = v.ln()),
-            UnaryOp::Neg => apply_inplace_unary(&mut dst[..len], |v| *v = T::zero() - *v),
-            UnaryOp::Sqr => apply_inplace_unary(&mut dst[..len], |v| *v = *v * *v),
-            UnaryOp::Sqrt => apply_inplace_unary(&mut dst[..len], |v| *v = v.sqrt()),
-            UnaryOp::Rsqrt => apply_inplace_unary(&mut dst[..len], |v| *v = T::one() / v.sqrt()),
-            UnaryOp::Abs => apply_inplace_unary(&mut dst[..len], |v| *v = v.abs()),
+            UnaryOp::Cos => apply_inplace_unary(chunk, &mut dst[..len], |v| *v = v.cos()),
+            UnaryOp::Sin => apply_inplace_unary(chunk, &mut dst[..len], |v| *v = v.sin()),
+            UnaryOp::Exp => apply_inplace_unary(chunk, &mut dst[..len], |v| *v = v.exp()),
+            UnaryOp::Log => apply_inplace_unary(chunk, &mut dst[..len], |v| *v = v.ln()),
+            UnaryOp::Neg => apply_inplace_unary(chunk, &mut dst[..len], |v| *v = T::zero() - *v),
+            UnaryOp::Sqr => apply_inplace_unary(chunk, &mut dst[..len], |v| *v = *v * *v),
+            UnaryOp::Sqrt => apply_inplace_unary(chunk, &mut dst[..len], |v| *v = v.sqrt()),
+            UnaryOp::Rsqrt => {
+                apply_inplace_unary(chunk, &mut dst[..len], |v| *v = T::one() / v.sqrt())
+            }
+            UnaryOp::Abs => apply_inplace_unary(chunk, &mut dst[..len], |v| *v = v.abs()),
             UnaryOp::GeluErf => {
                 let sqrt_2_inv = std::f32::consts::FRAC_1_SQRT_2;
-                apply_inplace_unary(&mut dst[..len], |v| {
+                apply_inplace_unary(chunk, &mut dst[..len], |v| {
                     let x = v.to_f32();
                     let erf_val = libm::erff(x * sqrt_2_inv);
                     *v = T::from_f32(x * 0.5 * (1.0 + erf_val));
                 })
             }
-            UnaryOp::Elu { alpha } => apply_inplace_unary(&mut dst[..len], |v| {
+            UnaryOp::Elu { alpha } => apply_inplace_unary(chunk, &mut dst[..len], |v| {
                 let x = v.to_f32();
                 *v = T::from_f32(if x > 0.0 { x } else { alpha * (x.exp() - 1.0) });
             }),
-            UnaryOp::Relu => apply_inplace_unary(&mut dst[..len], |v| {
+            UnaryOp::Relu => apply_inplace_unary(chunk, &mut dst[..len], |v| {
                 if *v < T::zero() {
                     *v = T::zero()
                 }
             }),
-            UnaryOp::Silu => apply_inplace_unary(&mut dst[..len], |v| {
+            UnaryOp::Silu => apply_inplace_unary(chunk, &mut dst[..len], |v| {
                 *v = *v / (T::one() + (T::zero() - *v).exp())
             }),
-            UnaryOp::Tanh => apply_inplace_unary(&mut dst[..len], |v| *v = v.tanh()),
-            UnaryOp::Sigmoid => apply_inplace_unary(&mut dst[..len], |v| {
+            UnaryOp::Tanh => apply_inplace_unary(chunk, &mut dst[..len], |v| *v = v.tanh()),
+            UnaryOp::Sigmoid => apply_inplace_unary(chunk, &mut dst[..len], |v| {
                 *v = T::one() / (T::one() + (T::zero() - *v).exp())
             }),
         }
@@ -217,37 +220,45 @@ impl crate::Backend for crate::CpuDevice {
         len: usize,
         op: UnaryOp,
     ) -> Result<()> {
+        let chunk = unary_chunk(op, len);
         match op {
-            UnaryOp::Cos => apply_unary(&mut dst[..len], &src[..len], |s| s.cos()),
-            UnaryOp::Sin => apply_unary(&mut dst[..len], &src[..len], |s| s.sin()),
-            UnaryOp::Exp => apply_unary(&mut dst[..len], &src[..len], |s| s.exp()),
-            UnaryOp::Log => apply_unary(&mut dst[..len], &src[..len], |s| s.ln()),
-            UnaryOp::Neg => apply_unary(&mut dst[..len], &src[..len], |s| T::zero() - s),
-            UnaryOp::Sqr => apply_unary(&mut dst[..len], &src[..len], |s| s * s),
-            UnaryOp::Sqrt => apply_unary(&mut dst[..len], &src[..len], |s| s.sqrt()),
-            UnaryOp::Rsqrt => apply_unary(&mut dst[..len], &src[..len], |s| T::one() / s.sqrt()),
-            UnaryOp::Abs => apply_unary(&mut dst[..len], &src[..len], |s| s.abs()),
+            UnaryOp::Cos => apply_unary(chunk, &mut dst[..len], &src[..len], |s| s.cos()),
+            UnaryOp::Sin => apply_unary(chunk, &mut dst[..len], &src[..len], |s| s.sin()),
+            UnaryOp::Exp => apply_unary(chunk, &mut dst[..len], &src[..len], |s| s.exp()),
+            UnaryOp::Log => apply_unary(chunk, &mut dst[..len], &src[..len], |s| s.ln()),
+            UnaryOp::Neg => apply_unary(chunk, &mut dst[..len], &src[..len], |s| T::zero() - s),
+            UnaryOp::Sqr => apply_unary(chunk, &mut dst[..len], &src[..len], |s| s * s),
+            UnaryOp::Sqrt => apply_unary(chunk, &mut dst[..len], &src[..len], |s| s.sqrt()),
+            UnaryOp::Rsqrt => {
+                apply_unary(chunk, &mut dst[..len], &src[..len], |s| T::one() / s.sqrt())
+            }
+            UnaryOp::Abs => apply_unary(chunk, &mut dst[..len], &src[..len], |s| s.abs()),
             UnaryOp::GeluErf => {
                 let sqrt_2_inv = std::f32::consts::FRAC_1_SQRT_2;
-                apply_unary(&mut dst[..len], &src[..len], |s| {
+                apply_unary(chunk, &mut dst[..len], &src[..len], |s| {
                     let x = s.to_f32();
                     let erf_val = libm::erff(x * sqrt_2_inv);
                     T::from_f32(x * 0.5 * (1.0 + erf_val))
                 })
             }
-            UnaryOp::Elu { alpha } => apply_unary(&mut dst[..len], &src[..len], |s| {
+            UnaryOp::Elu { alpha } => apply_unary(chunk, &mut dst[..len], &src[..len], |s| {
                 let x = s.to_f32();
                 T::from_f32(if x > 0.0 { x } else { alpha * (x.exp() - 1.0) })
             }),
             UnaryOp::Relu => {
                 let zero = T::zero();
-                apply_unary(&mut dst[..len], &src[..len], |s| if s < zero { zero } else { s })
+                apply_unary(
+                    chunk,
+                    &mut dst[..len],
+                    &src[..len],
+                    |s| if s < zero { zero } else { s },
+                )
             }
-            UnaryOp::Silu => apply_unary(&mut dst[..len], &src[..len], |s| {
+            UnaryOp::Silu => apply_unary(chunk, &mut dst[..len], &src[..len], |s| {
                 s / (T::one() + (T::zero() - s).exp())
             }),
-            UnaryOp::Tanh => apply_unary(&mut dst[..len], &src[..len], |s| s.tanh()),
-            UnaryOp::Sigmoid => apply_unary(&mut dst[..len], &src[..len], |s| {
+            UnaryOp::Tanh => apply_unary(chunk, &mut dst[..len], &src[..len], |s| s.tanh()),
+            UnaryOp::Sigmoid => apply_unary(chunk, &mut dst[..len], &src[..len], |s| {
                 T::one() / (T::one() + (T::zero() - s).exp())
             }),
         }
@@ -299,16 +310,18 @@ impl crate::Backend for crate::CpuDevice {
     ) -> Result<()> {
         let zero = T::zero();
         let one = T::one();
+        // An fma per element, so the fixed chunk applies (see `unary_chunk`).
+        let chunk = ELEMWISE_CHUNK;
         if add == zero && scale == one {
             Self::copy(dst, src, len)
         } else if add == zero {
-            apply_unary(&mut dst[..len], &src[..len], |s| s * scale);
+            apply_unary(chunk, &mut dst[..len], &src[..len], |s| s * scale);
             Ok(())
         } else if scale == one {
-            apply_unary(&mut dst[..len], &src[..len], |s| s + add);
+            apply_unary(chunk, &mut dst[..len], &src[..len], |s| s + add);
             Ok(())
         } else {
-            apply_unary(&mut dst[..len], &src[..len], |s| s * scale + add);
+            apply_unary(chunk, &mut dst[..len], &src[..len], |s| s * scale + add);
             Ok(())
         }
     }
@@ -1420,6 +1433,49 @@ const ELEMWISE_PAR_THRESHOLD: usize = 32 * 1024;
 /// Chunk size for parallel elementwise ops; large enough that the per-chunk dispatch cost is
 /// negligible and the inner loop auto-vectorizes.
 const ELEMWISE_CHUNK: usize = 64 * 1024;
+/// Floor on a pool-derived chunk (see `unary_chunk`): below this the per-chunk dispatch cost
+/// stops being negligible and the inner loop has too few iterations to auto-vectorize well.
+const ELEMWISE_MIN_CHUNK: usize = 4 * 1024;
+/// Chunks per thread for a pool-derived chunk. Splitting exactly `current_num_threads()` ways
+/// leaves rayon nothing to steal, and the cores here are not interchangeable: an E core takes
+/// several times longer over its chunk than a P core, and with one chunk each the whole op
+/// waits for it. Oversubscribing keeps the fast cores fed. This matters most with a small pool,
+/// where the chunks are large -- on a 4-thread pool, 1M `silu_` goes 487us -> 421us and 128K
+/// `silu_` 96us -> 80us just from this factor.
+const ELEMWISE_CHUNKS_PER_THREAD: usize = 4;
+
+/// Chunk size for a unary op over `len` elements.
+///
+/// `ELEMWISE_CHUNK` is a fixed 64K, so a length just past the parallelism threshold yields a
+/// single chunk -- rayon is entered but everything runs on one worker -- and the whole pool
+/// only gets work at `threads * ELEMWISE_CHUNK` (640K on a 10-thread pool). For a
+/// transcendental that is a lot of idle threads: one element costs tens of cycles, so a serial
+/// pass over 48K of them already costs ~50us against a ~20us fork/join, and splitting to match
+/// the pool is worth 1.6-1.9x from 32K to 128K.
+///
+/// The cheap ops keep the fixed chunk on purpose. An `Exp` element is ~20x a `Sqr` element, so
+/// for those a serial pass over the same 48K costs only a few us -- an order of magnitude below
+/// the fork/join -- and a real split is a 4-10x *loss*. Sizing their chunks by the pool is the
+/// one thing that must not happen here.
+fn unary_chunk(op: UnaryOp, len: usize) -> usize {
+    let transcendental = matches!(
+        op,
+        UnaryOp::Cos
+            | UnaryOp::Sin
+            | UnaryOp::Exp
+            | UnaryOp::Log
+            | UnaryOp::GeluErf
+            | UnaryOp::Elu { .. }
+            | UnaryOp::Silu
+            | UnaryOp::Tanh
+            | UnaryOp::Sigmoid
+    );
+    if !transcendental {
+        return ELEMWISE_CHUNK;
+    }
+    let threads = rayon::current_num_threads().max(1);
+    len.div_ceil(threads * ELEMWISE_CHUNKS_PER_THREAD).max(ELEMWISE_MIN_CHUNK)
+}
 
 /// Apply a binary operation in-place: dst[i] = op(dst[i], src[i])
 #[inline(always)]
@@ -1444,7 +1500,7 @@ where
 
 /// Apply a unary operation in-place: dst[i] = op(dst[i])
 #[inline(always)]
-fn apply_inplace_unary<T: Copy + Send + Sync, F>(dst: &mut [T], f: F)
+fn apply_inplace_unary<T: Copy + Send + Sync, F>(chunk: usize, dst: &mut [T], f: F)
 where
     F: Fn(&mut T) + Sync,
 {
@@ -1453,7 +1509,7 @@ where
             f(d);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).for_each(|dst| {
+        dst.par_chunks_mut(chunk).for_each(|dst| {
             for d in dst.iter_mut() {
                 f(d);
             }
@@ -1463,7 +1519,7 @@ where
 
 /// Apply a unary operation: dst[i] = op(src[i])
 #[inline(always)]
-fn apply_unary<T: Copy + Send + Sync, F>(dst: &mut [T], src: &[T], f: F)
+fn apply_unary<T: Copy + Send + Sync, F>(chunk: usize, dst: &mut [T], src: &[T], f: F)
 where
     F: Fn(T) -> T + Sync,
 {
@@ -1472,13 +1528,11 @@ where
             *d = f(*s);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
-            |(dst, src)| {
-                for (d, s) in dst.iter_mut().zip(src) {
-                    *d = f(*s);
-                }
-            },
-        );
+        dst.par_chunks_mut(chunk).zip(src.par_chunks(chunk)).for_each(|(dst, src)| {
+            for (d, s) in dst.iter_mut().zip(src) {
+                *d = f(*s);
+            }
+        });
     }
 }
 

--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -922,7 +922,10 @@ impl crate::Backend for crate::CpuDevice {
     ) -> Result<()> {
         let src = &src[..d * dim_m1];
         let dst = &mut dst[..d * dim_m1];
-        src.par_chunks(dim_m1).zip(dst.par_chunks_mut(dim_m1)).for_each(|(src, dst)| {
+        // Rows are independent, so this is gated the same way as the elementwise ops: during
+        // autoregressive decode a row is a single short attention vector, and the fork/join
+        // cost dominates the handful of exps it saves.
+        let softmax_row = |src: &[T], dst: &mut [T]| {
             let mut max = T::neg_infinity();
             for &v in src.iter() {
                 max = T::max(v, max)
@@ -934,7 +937,14 @@ impl crate::Backend for crate::CpuDevice {
             for d in dst.iter_mut() {
                 *d = T::from_f32(d.to_f32() / sum_exp)
             }
-        });
+        };
+        if use_parallelism(d * dim_m1) {
+            src.par_chunks(dim_m1)
+                .zip(dst.par_chunks_mut(dim_m1))
+                .for_each(|(s, d)| softmax_row(s, d));
+        } else {
+            src.chunks(dim_m1).zip(dst.chunks_mut(dim_m1)).for_each(|(s, d)| softmax_row(s, d));
+        }
         Ok(())
     }
 
@@ -1700,52 +1710,59 @@ fn conv_transpose1d_direct<T: WithDTypeF>(
         }
     }
 
-    // Process each kernel offset
-    for k_offset in 0..kernel_size {
-        // Parallelize over output channels
-        (0..out_channels).into_par_iter().for_each(|out_c| {
-            let g = out_c / out_c_per_group;
-            let oc_in_group = out_c % out_c_per_group;
-            let in_c_start = g * in_c_per_group;
+    // Each (b, out_c) pair owns a contiguous `out_length` slice of dst, so the op splits over
+    // those slices instead of over channels once per kernel offset. That means one fork/join
+    // for the whole call rather than `kernel_size` of them, safe mutable access instead of raw
+    // pointers, and no per-(channel, offset) weight buffer. Keeping k_offset outermost within
+    // a slice preserves the original accumulation order into dst, so results are unchanged.
+    let src_reordered = src_reordered.as_slice();
+    let accumulate = |bc: usize, dst_row: &mut [T]| {
+        let b = bc / out_channels;
+        let out_c = bc % out_channels;
+        let g = out_c / out_c_per_group;
+        let oc_in_group = out_c % out_c_per_group;
+        let in_c_start = g * in_c_per_group;
+        let src_row = &src_reordered[b * length * in_channels..(b + 1) * length * in_channels];
+        // Kernel layout: [in_channels, out_channels/groups, kernel_size]
+        let k_base = in_c_start * out_c_per_group * kernel_size + oc_in_group * kernel_size;
 
-            // Gather kernel weights for this output channel and kernel offset
-            // Kernel layout: [in_channels, out_channels/groups, kernel_size]
-            let k_cont: Vec<T> = (0..in_c_per_group)
-                .map(|ic| {
-                    let in_c = in_c_start + ic;
-                    let k_idx =
-                        in_c * out_c_per_group * kernel_size + oc_in_group * kernel_size + k_offset;
-                    kernel[k_idx]
-                })
-                .collect();
-
-            for b in 0..batch {
+        if in_c_per_group == 1 {
+            // Depthwise: the dot product over input channels collapses to a single multiply,
+            // and this channel's kernel taps are contiguous.
+            let w = &kernel[k_base..k_base + kernel_size];
+            for (k_offset, &wk) in w.iter().enumerate() {
                 for il in 0..length {
                     let out_pos_raw = il * stride + k_offset;
-
-                    // Check padding bounds
                     if out_pos_raw < padding || out_pos_raw >= out_length + padding {
                         continue;
                     }
-                    let out_pos = out_pos_raw - padding;
-
-                    // Compute dot product over input channels
-                    let src_base = b * length * in_channels + il * in_channels + in_c_start;
-                    let mut d = T::zero();
-                    for ic in 0..in_c_per_group {
-                        d += src_reordered[src_base + ic] * k_cont[ic];
-                    }
-
-                    // Accumulate into output
-                    // Safety: each out_c is processed by a different thread, so no races
-                    let dst_idx = b * out_channels * out_length + out_c * out_length + out_pos;
-                    unsafe {
-                        let ptr = dst.as_ptr().add(dst_idx) as *mut T;
-                        *ptr += d;
-                    }
+                    dst_row[out_pos_raw - padding] += src_row[il * in_channels + in_c_start] * wk;
                 }
             }
-        });
+        } else {
+            for k_offset in 0..kernel_size {
+                for il in 0..length {
+                    let out_pos_raw = il * stride + k_offset;
+                    if out_pos_raw < padding || out_pos_raw >= out_length + padding {
+                        continue;
+                    }
+                    let src_base = il * in_channels + in_c_start;
+                    let mut acc = T::zero();
+                    for ic in 0..in_c_per_group {
+                        let k_idx = k_base + ic * out_c_per_group * kernel_size + k_offset;
+                        acc += src_row[src_base + ic] * kernel[k_idx];
+                    }
+                    dst_row[out_pos_raw - padding] += acc;
+                }
+            }
+        }
+    };
+
+    let dst = &mut dst[..batch * out_channels * out_length];
+    if use_parallelism(batch * out_channels * kernel_size * length) {
+        dst.par_chunks_mut(out_length).enumerate().for_each(|(bc, d)| accumulate(bc, d));
+    } else {
+        dst.chunks_mut(out_length).enumerate().for_each(|(bc, d)| accumulate(bc, d));
     }
     Ok(())
 }

--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -417,10 +417,9 @@ impl crate::Backend for crate::CpuDevice {
         if !use_parallelism(l) {
             dst[..l].copy_from_slice(&src[..l]);
         } else {
-            let chunk = elemwise_chunk(l);
             dst[..l]
-                .par_chunks_mut(chunk)
-                .zip(src[..l].par_chunks(chunk))
+                .par_chunks_mut(ELEMWISE_CHUNK)
+                .zip(src[..l].par_chunks(ELEMWISE_CHUNK))
                 .for_each(|(d, s)| d.copy_from_slice(s));
         }
         Ok(())
@@ -493,7 +492,7 @@ impl crate::Backend for crate::CpuDevice {
             }
         };
         if use_parallelism(len) {
-            dst[..len].par_chunks_mut(elemwise_chunk(len)).for_each(fill);
+            dst[..len].par_chunks_mut(ELEMWISE_CHUNK).for_each(fill);
         } else {
             fill(&mut dst[..len]);
         }
@@ -514,7 +513,7 @@ impl crate::Backend for crate::CpuDevice {
             }
         };
         if use_parallelism(len) {
-            dst[..len].par_chunks_mut(elemwise_chunk(len)).for_each(fill);
+            dst[..len].par_chunks_mut(ELEMWISE_CHUNK).for_each(fill);
         } else {
             fill(&mut dst[..len]);
         }
@@ -525,7 +524,7 @@ impl crate::Backend for crate::CpuDevice {
         if !use_parallelism(l) {
             dst[..l].fill(v);
         } else {
-            dst[..l].par_chunks_mut(elemwise_chunk(l)).for_each(|d| d.fill(v));
+            dst[..l].par_chunks_mut(ELEMWISE_CHUNK).for_each(|d| d.fill(v));
         }
         Ok(())
     }
@@ -1418,19 +1417,9 @@ fn reduce_arg<T: WithDType + Copy>(
 /// Below this many elements, elementwise ops run serially: the rayon fork/join overhead
 /// (~10us) dwarfs the work itself.
 const ELEMWISE_PAR_THRESHOLD: usize = 32 * 1024;
-/// Floor on the chunk size for parallel elementwise ops: below this the per-chunk dispatch
-/// cost stops being negligible and the inner loop has too few iterations to auto-vectorize
-/// well.
-const ELEMWISE_MIN_CHUNK: usize = 4 * 1024;
-
-/// Chunk size for parallel elementwise ops. This has to be derived from the work and the pool
-/// size rather than being a fixed constant: a constant larger than ELEMWISE_PAR_THRESHOLD
-/// means every length between the threshold and that constant yields a single chunk, paying
-/// the fork/join cost for no parallelism at all.
-fn elemwise_chunk(len: usize) -> usize {
-    let threads = rayon::current_num_threads().max(1);
-    len.div_ceil(threads).max(ELEMWISE_MIN_CHUNK)
-}
+/// Chunk size for parallel elementwise ops; large enough that the per-chunk dispatch cost is
+/// negligible and the inner loop auto-vectorizes.
+const ELEMWISE_CHUNK: usize = 64 * 1024;
 
 /// Apply a binary operation in-place: dst[i] = op(dst[i], src[i])
 #[inline(always)]
@@ -1443,8 +1432,7 @@ where
             f(d, *s);
         }
     } else {
-        let chunk = elemwise_chunk(dst.len());
-        dst.par_chunks_mut(chunk).zip(src.par_chunks(chunk)).for_each(
+        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
             |(dst, src)| {
                 for (d, s) in dst.iter_mut().zip(src) {
                     f(d, *s);
@@ -1465,7 +1453,7 @@ where
             f(d);
         }
     } else {
-        dst.par_chunks_mut(elemwise_chunk(dst.len())).for_each(|dst| {
+        dst.par_chunks_mut(ELEMWISE_CHUNK).for_each(|dst| {
             for d in dst.iter_mut() {
                 f(d);
             }
@@ -1484,8 +1472,7 @@ where
             *d = f(*s);
         }
     } else {
-        let chunk = elemwise_chunk(dst.len());
-        dst.par_chunks_mut(chunk).zip(src.par_chunks(chunk)).for_each(
+        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
             |(dst, src)| {
                 for (d, s) in dst.iter_mut().zip(src) {
                     *d = f(*s);
@@ -1506,9 +1493,8 @@ where
             *d = f(*l, *r);
         }
     } else {
-        let chunk = elemwise_chunk(dst.len());
-        dst.par_chunks_mut(chunk)
-            .zip(lhs.par_chunks(chunk).zip(rhs.par_chunks(chunk)))
+        dst.par_chunks_mut(ELEMWISE_CHUNK)
+            .zip(lhs.par_chunks(ELEMWISE_CHUNK).zip(rhs.par_chunks(ELEMWISE_CHUNK)))
             .for_each(|(dst, (lhs, rhs))| {
                 for ((d, l), r) in dst.iter_mut().zip(lhs).zip(rhs) {
                     *d = f(*l, *r);
@@ -1726,9 +1712,9 @@ fn conv_transpose1d_direct<T: WithDTypeF>(
 
     // Each (b, out_c) pair owns a contiguous `out_length` slice of dst, so the op splits over
     // those slices instead of over channels once per kernel offset. That means one fork/join
-    // for the whole call rather than `kernel_size` of them, safe mutable access instead of raw
-    // pointers, and no per-(channel, offset) weight buffer. Keeping k_offset outermost within
-    // a slice preserves the original accumulation order into dst, so results are unchanged.
+    // for the whole call rather than `kernel_size` of them, and safe mutable access instead of
+    // raw pointers. Keeping k_offset outermost within a slice preserves the original
+    // accumulation order into dst, so results are unchanged.
     let src_reordered = src_reordered.as_slice();
     let accumulate = |bc: usize, dst_row: &mut [T]| {
         let b = bc / out_channels;
@@ -1754,7 +1740,16 @@ fn conv_transpose1d_direct<T: WithDTypeF>(
                 }
             }
         } else {
+            // This channel's taps for a given k_offset sit `out_c_per_group * kernel_size`
+            // apart in `kernel`, so gather them once per offset rather than reading them
+            // strided inside the `il` loop: the dot product below then walks two contiguous
+            // buffers and vectorizes. The gather costs one `in_c_per_group` copy per
+            // (slice, offset), which is `length` times less work than the loop it feeds.
+            let mut k_cont = vec![T::zero(); in_c_per_group];
             for k_offset in 0..kernel_size {
+                for (ic, kc) in k_cont.iter_mut().enumerate() {
+                    *kc = kernel[k_base + ic * out_c_per_group * kernel_size + k_offset];
+                }
                 for il in 0..length {
                     let out_pos_raw = il * stride + k_offset;
                     if out_pos_raw < padding || out_pos_raw >= out_length + padding {
@@ -1762,9 +1757,8 @@ fn conv_transpose1d_direct<T: WithDTypeF>(
                     }
                     let src_base = il * in_channels + in_c_start;
                     let mut acc = T::zero();
-                    for ic in 0..in_c_per_group {
-                        let k_idx = k_base + ic * out_c_per_group * kernel_size + k_offset;
-                        acc += src_row[src_base + ic] * kernel[k_idx];
+                    for (ic, &kc) in k_cont.iter().enumerate() {
+                        acc += src_row[src_base + ic] * kc;
                     }
                     dst_row[out_pos_raw - padding] += acc;
                 }

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1009,6 +1009,130 @@ test_all_backends!(
     test_conv_transpose1d_batch_with_bias_impl
 );
 
+// -----------------------------------------------------------------------------
+// conv_transpose1d fallback path (cpu)
+//
+// The col2im fast path only applies when groups == 1 && padding == 0 &&
+// output_padding == 0; anything else goes through conv_transpose1d_direct. The tests above
+// all satisfy the fast-path condition, so these cover the fallback by equivalence against
+// the fast path.
+// -----------------------------------------------------------------------------
+
+/// Grouped conv_transpose1d equals per-group conv_transpose1d (groups=1) concatenated along
+/// the channel axis. The reference side takes the well-covered col2im path.
+fn check_grouped_matches_per_group(
+    batch: usize,
+    in_channels: usize,
+    out_c_per_group: usize,
+    length: usize,
+    kernel_size: usize,
+    stride: usize,
+    groups: usize,
+) -> Result<()> {
+    let dev = &xn::CPU;
+    let in_c_per_group = in_channels / groups;
+    let n_in = batch * in_channels * length;
+    let n_k = in_channels * out_c_per_group * kernel_size;
+    // Deterministic, non-symmetric values so channel/offset mix-ups actually show up.
+    let input: Tensor<f32, _> =
+        Tensor::from_vec((0..n_in).map(|i| (i % 7) as f32 - 3.).collect(), (batch, in_channels, length), dev)?;
+    let kernel: Tensor<f32, _> = Tensor::from_vec(
+        (0..n_k).map(|i| ((i % 5) as f32 - 2.) * 0.5).collect(),
+        (in_channels, out_c_per_group, kernel_size),
+        dev,
+    )?;
+
+    let got = input.conv_transpose1d(&kernel, None, stride, 0, 0, groups)?;
+
+    let mut parts = Vec::new();
+    for g in 0..groups {
+        let ic0 = g * in_c_per_group;
+        let sub_in = input.narrow(1, ic0..ic0 + in_c_per_group)?.contiguous()?;
+        let sub_k = kernel.narrow(0, ic0..ic0 + in_c_per_group)?.contiguous()?;
+        parts.push(sub_in.conv_transpose1d(&sub_k, None, stride, 0, 0, 1)?);
+    }
+    let refs: Vec<&Tensor<f32, _>> = parts.iter().collect();
+    let want = Tensor::cat(&refs, 1)?;
+
+    assert_eq!(got.dims(), want.dims(), "shape mismatch");
+    let (g, w) = (got.to_vec()?, want.to_vec()?);
+    for (i, (a, b)) in g.iter().zip(w.iter()).enumerate() {
+        assert!((a - b).abs() < 1e-4, "index {i}: got {a}, want {b}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_conv_transpose1d_depthwise_cpu() -> Result<()> {
+    // groups == in_channels == out_channels: the depthwise branch.
+    check_grouped_matches_per_group(1, 8, 1, 5, 4, 2, 8)?;
+    check_grouped_matches_per_group(2, 6, 1, 4, 6, 3, 6)?;
+    // Shaped like mimi's frame-rate adapter: kernel_size == 2 * stride, depthwise.
+    check_grouped_matches_per_group(1, 16, 1, 3, 8, 4, 16)
+}
+
+#[test]
+fn test_conv_transpose1d_grouped_cpu() -> Result<()> {
+    // 1 < groups < in_channels, so in_c_per_group > 1 (the general fallback branch).
+    check_grouped_matches_per_group(1, 8, 2, 5, 3, 1, 2)?;
+    check_grouped_matches_per_group(2, 12, 3, 4, 4, 2, 4)?;
+    // out_c_per_group > 1 together with in_c_per_group == 1 exercises the depthwise branch's
+    // kernel indexing without groups == out_channels.
+    check_grouped_matches_per_group(1, 4, 3, 4, 3, 2, 4)
+}
+
+#[test]
+fn test_conv_transpose1d_padding_crops_cpu() -> Result<()> {
+    // padding p on a transposed conv drops p elements from each end of the output.
+    let dev = &xn::CPU;
+    let input: Tensor<f32, _> =
+        Tensor::from_vec((0..12).map(|i| (i % 5) as f32 - 2.).collect(), (1, 3, 4), dev)?;
+    let kernel: Tensor<f32, _> =
+        Tensor::from_vec((0..18).map(|i| (i % 4) as f32 - 1.).collect(), (3, 2, 3), dev)?;
+
+    let unpadded = input.conv_transpose1d(&kernel, None, 2, 0, 0, 1)?;
+    let full_len = unpadded.dims()[2];
+    for p in 1..=2 {
+        let padded = input.conv_transpose1d(&kernel, None, 2, p, 0, 1)?;
+        assert_eq!(padded.dims(), &[1, 2, full_len - 2 * p], "padding {p} shape");
+        let want = unpadded.narrow(2, p..full_len - p)?.contiguous()?.to_vec()?;
+        let got = padded.to_vec()?;
+        for (i, (a, b)) in got.iter().zip(want.iter()).enumerate() {
+            assert!((a - b).abs() < 1e-4, "padding {p} index {i}: got {a}, want {b}");
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_conv_transpose1d_output_padding_appends_zeros_cpu() -> Result<()> {
+    // output_padding only extends the output; the extra tail positions receive no
+    // contributions and stay zero.
+    let dev = &xn::CPU;
+    let input: Tensor<f32, _> =
+        Tensor::from_vec((0..8).map(|i| (i % 3) as f32 - 1.).collect(), (1, 2, 4), dev)?;
+    let kernel: Tensor<f32, _> =
+        Tensor::from_vec((0..8).map(|i| (i % 3) as f32).collect(), (2, 2, 2), dev)?;
+
+    let base = input.conv_transpose1d(&kernel, None, 2, 0, 0, 1)?;
+    let base_len = base.dims()[2];
+    let base_v = base.to_vec()?;
+    let q = 3;
+    let extended = input.conv_transpose1d(&kernel, None, 2, 0, q, 1)?;
+    assert_eq!(extended.dims(), &[1, 2, base_len + q]);
+    let ext_v = extended.to_vec()?;
+    for c in 0..2 {
+        for i in 0..base_len {
+            let (a, b) = (ext_v[c * (base_len + q) + i], base_v[c * base_len + i]);
+            assert!((a - b).abs() < 1e-4, "ch {c} index {i}: got {a}, want {b}");
+        }
+        for i in base_len..base_len + q {
+            assert_eq!(ext_v[c * (base_len + q) + i], 0., "ch {c} tail index {i} not zero");
+        }
+    }
+    Ok(())
+}
+
 // =============================================================================
 // Pad with same tests
 // =============================================================================

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1034,8 +1034,11 @@ fn check_grouped_matches_per_group(
     let n_in = batch * in_channels * length;
     let n_k = in_channels * out_c_per_group * kernel_size;
     // Deterministic, non-symmetric values so channel/offset mix-ups actually show up.
-    let input: Tensor<f32, _> =
-        Tensor::from_vec((0..n_in).map(|i| (i % 7) as f32 - 3.).collect(), (batch, in_channels, length), dev)?;
+    let input: Tensor<f32, _> = Tensor::from_vec(
+        (0..n_in).map(|i| (i % 7) as f32 - 3.).collect(),
+        (batch, in_channels, length),
+        dev,
+    )?;
     let kernel: Tensor<f32, _> = Tensor::from_vec(
         (0..n_k).map(|i| ((i % 5) as f32 - 2.) * 0.5).collect(),
         (in_channels, out_c_per_group, kernel_size),


### PR DESCRIPTION
# CPU backend: fix three places where rayon is used at the wrong granularity

Branch: `perf/cpu-conv-tr-and-softmax` — `xn-core/src/cpu_backend.rs` + tests.

## Summary

Three independent changes. The first two are about not paying for parallelism that cannot help
-- a rayon fork/join costs ~20us here, more than many ops cost in total. The third is the
opposite case: work that is expensive enough to split, but which the fixed chunk size never
actually spread across the pool.

**1. `softmax` is gated by `use_parallelism`.** Rows were unconditionally dispatched with
`par_chunks`. During decode a row is one short attention vector, so the fork/join dwarfed the
handful of `exp`s it saved. This is the same gate the rest of the file already applies; above the
threshold the code path is unchanged.

**2. `conv_transpose1d_direct` splits over `(batch, out_channel)` output slices** instead of over
output channels once per kernel offset. Each `(b, out_c)` pair owns a contiguous `out_length`
slice of `dst`, which gives:

- one fork/join per call instead of `kernel_size` of them,
- safe `&mut [T]` slices instead of `unsafe` raw-pointer accumulation into `dst`,
- a depthwise (`in_c_per_group == 1`) branch where the dot product over input channels collapses
  to a single multiply against contiguous kernel taps,
- the per-`(slice, k_offset)` `k_cont` gather kept for the general branch — a channel's taps sit
  `out_c_per_group * kernel_size` apart, so gathering them once per offset keeps the inner dot
  product walking two contiguous buffers instead of reading `kernel` strided `length` times.

`k_offset` stays outermost within a slice, so the accumulation order into `dst` is unchanged and
results are bit-identical.

This is the fallback path: col2im handles `groups == 1 && padding == 0 && output_padding == 0`,
everything else lands here — so every grouped, depthwise, or padded transposed conv.

**3. Transcendental unary ops now chunk by pool size.** `ELEMWISE_CHUNK` is a fixed 64K while
the parallelism threshold is 32K, so any length in `[32K, 64K]` produced exactly one chunk --
rayon entered, then did all the work on one worker -- and the whole pool only got work at
`threads * 64K` (640K on a 10-thread pool). `unary_chunk(op, len)` now derives the chunk from the
pool for the transcendental ops (`exp`, `log`, `sin`, `cos`, `tanh`, `sigmoid`, `silu`, `gelu`,
`elu`), which are the ones whose per-element cost is high enough for a real split to pay.

Two details matter:

- *Everything else keeps the fixed 64K chunk, deliberately.* An `Exp` element is ~20x a `Sqr`
  element. At 48K a serial `exp_` pass costs ~50us and wants all 10 threads; a serial `sqr_` or
  `copy_` pass costs 2-5us, an order of magnitude *below* the fork/join, so splitting it is a
  4-10x loss. That asymmetry is why this is scoped to one op class instead of applied to the
  elementwise family as a whole.
- *The split oversubscribes 4 chunks per thread.* One chunk per thread leaves rayon nothing to
  steal, and the cores are not interchangeable -- an E core takes several times longer over its
  chunk than a P core, and the op waits for it. This is invisible on a 10-thread pool but severe
  on a small one: at T=4, one-chunk-per-thread measured 0.84-0.87x vs `main` at 128K and 1M,
  where 4-per-thread gets 1.35x and parity.

**Tests.** Four new CPU tests cover that fallback path, which previously had **no** coverage —
every existing `conv_transpose1d` test satisfied the col2im fast-path condition. They pin the
fallback by equivalence against the well-covered fast path: grouped equals per-group concatenated
along the channel axis, padding crops the output symmetrically, and `output_padding` only appends
zeros. Full workspace suite: 15 test binaries, 0 failures (154 tests in `xn`);
`cargo clippy --all-targets` clean.

## Benchmarks

Apple M5 (4 P cores + 6 E cores), `--release`, f32. us/iter, lower is better; median of 5
alternating runs for the conv and softmax tables, 3 for the elementwise ones. Run at three rayon
pool sizes via `RAYON_NUM_THREADS`, since every one of these changes trades parallelism against
fork/join and the balance moves with pool size: `T=10` is the default pool, `T=4` matches the
P-core count, `T=3` is a smaller pool still. Cells are `main -> this PR (speedup)`.

### conv_transpose1d — direct/fallback path

| case | T=3 | T=4 | T=10 |
|---|---:|---:|---:|
| stream, depthwise `c=512 l=1 k=12 s=6 g=512` | 155.6 -> **7.3** (21.4x) | 212.3 -> **8.1** (26.2x) | 369.0 -> **8.1** (45.5x) |
| depthwise `c=512 l=16 k=12 s=6 g=512` | 222.8 -> **37.8** (5.9x) | 288.5 -> **45.6** (6.3x) | 455.2 -> **54.5** (8.4x) |
| depthwise `c=128 l=480 k=8 s=4 g=128` | 364.4 -> **167.1** (2.2x) | 401.5 -> **171.0** (2.3x) | 442.7 -> **193.3** (2.3x) |
| depthwise `c=64 l=1920 k=8 s=4 g=64` | 647.3 -> **322.6** (2.0x) | 689.6 -> **299.8** (2.3x) | 599.3 -> **317.6** (1.9x) |
| grouped `c=256 l=96 k=10 s=5 g=4` | 2593.8 -> **993.7** (2.6x) | 2244.6 -> **855.0** (2.6x) | 1396.2 -> **642.3** (2.2x) |
| grouped `c=64 l=480 k=8 s=4 g=8` | 395.4 -> **301.9** (1.3x) | 473.1 -> **274.1** (1.7x) | 449.6 -> **245.2** (1.8x) |
| padded `g=1 c=512 l=64 k=12 s=6 p=3` | 21149.8 -> **13051.8** (1.6x) | 17998.6 -> **10067.7** (1.8x) | 8953.0 -> **6067.9** (1.5x) |
| padded `g=1 c=128 l=480 k=8 s=4 p=2` | 5116.9 -> **2420.5** (2.1x) | 4367.4 -> **1978.7** (2.2x) | 2718.8 -> **1385.9** (2.0x) |

The restructure wins at every pool size. It gains most with a large pool, because that is where
`main`'s `kernel_size` fork/joins cost the most, but even a 3-thread pool keeps 1.3x-21x.

### softmax

| case | T=3 | T=4 | T=10 |
|---|---:|---:|---:|
| decode `d=32 dim=64` (2K elems) | 8.0 -> **2.9** (2.8x) | 10.7 -> **3.2** (3.3x) | 26.2 -> **3.2** (8.2x) |
| decode `d=32 dim=256` (8K elems) | 11.6 -> 13.5 (0.86x) | 15.4 -> **14.5** (1.06x) | 27.9 -> **14.5** (1.9x) |
| decode `d=8 dim=1024` (8K elems) | 11.5 -> 13.3 (0.86x) | 14.5 -> 14.6 (0.99x) | 24.5 -> **14.6** (1.7x) |
| prefill `d=32 dim=2048` (64K elems) | 45.5 -> 46.8 (0.97x) | 47.3 -> **46.0** (1.03x) | 41.5 -> 41.4 (1.00x) |
| prefill `d=256 dim=4096` (1M elems) | 641.1 -> 652.1 (0.98x) | 544.8 -> **540.1** (1.01x) | 320.8 -> 321.3 (1.00x) |

The prefill rows are above the threshold and unchanged, as expected. The interesting rows are the
8K ones: **the gate costs ~2us there on a 3-thread pool** (0.86x), is neutral at 4 threads, and
wins 1.7-1.9x at 10. That is the threshold showing its one real limitation -- fork/join cost grows
with pool size, so the work at which parallelism starts to pay grows too, and a single constant
(32K) cannot sit at the right place for every pool. At 3 threads the true break-even for a row of
`exp`s is below 8K; at 10 threads it is above it. The 2K row wins at every size, and the ~2us
worst case is small next to the 12-24us the gate saves in the cases it targets, so this keeps one
shared constant rather than scaling it by `current_num_threads()`.

### Transcendental unary ops (`silu_`, `exp_`)

The range the fixed chunk never parallelized. Cells are `main -> this PR (speedup)`:

| len | op | T=3 | T=4 | T=10 |
|---|---|---:|---:|---:|
| 32K | `silu_` | 42.8 -> **20.9** (2.1x) | 38.4 -> **23.4** (1.6x) | 38.5 -> **29.6** (1.3x) |
| 32K | `exp_` | 40.9 -> **21.5** (1.9x) | 38.6 -> **23.3** (1.7x) | 36.3 -> **29.4** (1.2x) |
| 48K | `silu_` | 58.5 -> **29.3** (2.0x) | 54.1 -> **30.0** (1.8x) | 54.1 -> **30.6** (1.8x) |
| 48K | `exp_` | 55.2 -> **29.1** (1.9x) | 54.1 -> **30.0** (1.8x) | 52.7 -> **30.0** (1.8x) |
| 64K | `silu_` | 72.4 -> **34.8** (2.1x) | 71.0 -> **34.9** (2.0x) | 70.9 -> **38.1** (1.9x) |
| 64K | `exp_` | 71.6 -> **35.8** (2.0x) | 72.6 -> **35.0** (2.1x) | 68.2 -> **37.1** (1.8x) |
| 128K | `silu_` | 78.7 -> **64.3** (1.2x) | 81.9 -> **60.5** (1.4x) | 98.9 -> **53.5** (1.9x) |
| 128K | `exp_` | 77.1 -> **66.8** (1.2x) | 80.7 -> **62.0** (1.3x) | 98.0 -> **51.2** (1.9x) |
| 1M | `silu_` | 490.9 -> **465.4** (1.05x) | 416.8 -> 423.1 (0.99x) | 310.3 -> **269.7** (1.15x) |
| 1M | `exp_` | 480.9 -> **456.7** (1.05x) | 401.2 -> 402.2 (1.00x) | 303.7 -> **251.4** (1.21x) |

1.2-2.1x from 32K to 128K at every pool size, and no regression at 1M, where the fixed chunk
already produced enough chunks to spread. In model terms this is mid-size activation tensors --
hidden 4096 x 8-64 tokens. Single-token decode activations are ~4-11K elements, below the 32K
parallelism threshold, so they are serial either way.

### Cheap elementwise ops (unchanged -- regression check)

`add_`, `sqr_` and `copy_` are unchanged **by construction**: binary ops, `copy`, `fill`, `randn`
and `scale_add` never call `unary_chunk`, and for a non-transcendental unary it returns
`ELEMWISE_CHUNK`, so those paths are byte-identical to `main`. Measured across 32K-1M at T=3/4/10
they land between 0.81x and 1.17x with no systematic direction -- that spread is the measurement
noise on bandwidth-bound ops, which is why the guarantee above is structural rather than
empirical. `ELEMWISE_CHUNK` and `ELEMWISE_PAR_THRESHOLD` keep `main`'s values.

## Notes

- Still untuned, deliberately: the 32K `ELEMWISE_PAR_THRESHOLD` is too low for bandwidth-bound
  ops -- `copy_` at 128K measures 23.6us parallel (T=10) vs 5.8us serial on this machine, i.e.
  `main` loses 4x by parallelizing at all. That predates this branch. Fixing it means a
  per-element cost notion for the *threshold* too, and is left out of scope here.
