### PR TITLE
feat: instrument quantized gemm

### DIFF
--- a/xn-core/src/cuda_backend/quantization.rs
+++ b/xn-core/src/cuda_backend/quantization.rs
@@ -48,6 +48,7 @@ pub struct Fp8Tensor {
 
 impl Fp8Tensor {
     /// Quantize a `Tensor<T, Device>` into an `Fp8Tensor` using dynamic per-tensor scaling.
+    #[tracing::instrument(name = "fp8-quantize", skip_all)]
     pub fn quantize<T: Fp8Quantizable>(src: &Tensor<T, Device>) -> Result<Self> {
         let shape = src.shape();
         let hidden_size = shape.dim(crate::D::Minus1)?;
@@ -57,6 +58,7 @@ impl Fp8Tensor {
     }
 
     /// Quantize a `Tensor<T, Device>` into an `Fp8Tensor` using dynamic per-token scaling.
+    #[tracing::instrument(name = "fp8-quantize-per-token", skip_all)]
     pub fn quantize_per_token<T: Fp8Quantizable>(src: &Tensor<T, Device>) -> Result<Self> {
         let shape = src.shape();
         let hidden_size = shape.dim(crate::D::Minus1)?;
@@ -72,6 +74,7 @@ impl Fp8Tensor {
     }
 
     /// Dequantize this `Fp8Tensor` back to a `Tensor<T, Device>`.
+    #[tracing::instrument(name = "fp8-dequantize", skip_all)]
     pub fn dequantize<T: Fp8Quantizable>(&self) -> Result<Tensor<T, Device>> {
         let numel = self.shape.elem_count();
         let mut out: CudaSlice<T> = unsafe { self.device.stream().alloc::<T>(numel) }?;
@@ -127,6 +130,7 @@ impl Fp8Tensor {
     /// Mixing per-tensor with per-token is not supported because cuBLASLt
     /// requires both A and B scale modes to be set together.
     /// Requires a GPU with compute cap >= 8.9 (Ada Lovelace / Hopper).
+    #[tracing::instrument(name = "fp8-matmul-t", skip_all)]
     pub fn matmul_t(&self, rhs: &Fp8Tensor) -> Result<Tensor<bf16, Device>> {
         let self_dims = self.shape.dims();
         let rhs_dims = rhs.shape.dims();
@@ -365,6 +369,7 @@ impl Fp8Linear {
     ///
     /// Supports batched inputs: `xs` can be `[..batch, M, K]`. Batch dims are
     /// flattened into M for the FP8 matmul and restored on output.
+    #[tracing::instrument(name = "fp8-linear-forward", skip_all)]
     pub fn forward(&self, xs: &Tensor<bf16, Device>) -> Result<Tensor<bf16, Device>> {
         let dims = xs.dims();
         let rank = dims.len();

--- a/xn-core/src/quantized/k_quants.rs
+++ b/xn-core/src/quantized/k_quants.rs
@@ -50,7 +50,7 @@ pub trait GgmlType: Sized + Clone + Send + Sync {
     }
 }
 
-#[tracing::instrument(name = "q-matmul-by-row", skip_all)]
+#[tracing::instrument(name = "q-matmul-by-row", skip_all, fields(m = m, n = n, k = k))]
 fn matmul_by_row<T: GgmlType>(
     lhs_b: &[T::VecDotType],
     rhs_t: &[T],
@@ -708,7 +708,7 @@ impl GgmlType for BlockQ8_0 {
 // sgemm with `(m', n') = (n, m)` and `ldc = n`. Then sgemm's
 // `c[n * i + j]` lines up with `dst[i * n + j]`.
 #[cfg(any(target_feature = "avx", target_feature = "neon", target_feature = "simd128"))]
-#[tracing::instrument(name = "q-matmul-q8-0-sgemm", skip_all)]
+#[tracing::instrument(name = "q-matmul-q8-0-sgemm", skip_all, fields(m = m, n = n, k = k))]
 fn matmul_q8_0_sgemm(
     lhs_b: &[BlockQ8_0],
     rhs_t: &[BlockQ8_0],
@@ -1957,7 +1957,7 @@ impl GgmlType for BlockQ8K {
 }
 
 // https://github.com/ggerganov/llama.cpp/blob/b5ffb2849d23afe73647f68eec7b68187af09be6/ggml.c#L10605
-#[tracing::instrument(name = "q-matmul", skip_all)]
+#[tracing::instrument(name = "q-matmul", skip_all, fields(m = mkn.0, n = mkn.2, k = mkn.1))]
 pub fn matmul<T: GgmlType>(
     mkn: (usize, usize, usize),
     lhs: &[f32],
@@ -1975,7 +1975,7 @@ pub fn matmul<T: GgmlType>(
 }
 
 // Quantize the f32 lhs rows into the rhs type's vec-dot blocks.
-#[tracing::instrument(name = "q-matmul-quantize-lhs", skip_all)]
+#[tracing::instrument(name = "q-matmul-quantize-lhs", skip_all, fields(m = m, k = k))]
 fn quantize_lhs<T: GgmlType>(m: usize, k: usize, lhs: &[f32]) -> Result<Vec<T::VecDotType>> {
     let k_in_lhs_blocks = k.div_ceil(T::BLCK_SIZE);
     // TODO: Do not make this copy if the DotType is f32.

--- a/xn-core/src/quantized/k_quants.rs
+++ b/xn-core/src/quantized/k_quants.rs
@@ -50,6 +50,7 @@ pub trait GgmlType: Sized + Clone + Send + Sync {
     }
 }
 
+#[tracing::instrument(name = "q-matmul-by-row", skip_all)]
 fn matmul_by_row<T: GgmlType>(
     lhs_b: &[T::VecDotType],
     rhs_t: &[T],
@@ -707,6 +708,7 @@ impl GgmlType for BlockQ8_0 {
 // sgemm with `(m', n') = (n, m)` and `ldc = n`. Then sgemm's
 // `c[n * i + j]` lines up with `dst[i * n + j]`.
 #[cfg(any(target_feature = "avx", target_feature = "neon", target_feature = "simd128"))]
+#[tracing::instrument(name = "q-matmul-q8-0-sgemm", skip_all)]
 fn matmul_q8_0_sgemm(
     lhs_b: &[BlockQ8_0],
     rhs_t: &[BlockQ8_0],
@@ -1955,6 +1957,7 @@ impl GgmlType for BlockQ8K {
 }
 
 // https://github.com/ggerganov/llama.cpp/blob/b5ffb2849d23afe73647f68eec7b68187af09be6/ggml.c#L10605
+#[tracing::instrument(name = "q-matmul", skip_all)]
 pub fn matmul<T: GgmlType>(
     mkn: (usize, usize, usize),
     lhs: &[f32],
@@ -1966,6 +1969,14 @@ pub fn matmul<T: GgmlType>(
         crate::bail!("unexpected lhs length {} {mkn:?}", lhs.len());
     }
 
+    let lhs_b = quantize_lhs::<T>(m, k, lhs)?;
+    T::matmul(lhs_b.as_slice(), rhs_t, dst, m, n, k)?;
+    Ok(())
+}
+
+// Quantize the f32 lhs rows into the rhs type's vec-dot blocks.
+#[tracing::instrument(name = "q-matmul-quantize-lhs", skip_all)]
+fn quantize_lhs<T: GgmlType>(m: usize, k: usize, lhs: &[f32]) -> Result<Vec<T::VecDotType>> {
     let k_in_lhs_blocks = k.div_ceil(T::BLCK_SIZE);
     // TODO: Do not make this copy if the DotType is f32.
     // TODO: Pre-allocate this.
@@ -1975,9 +1986,7 @@ pub fn matmul<T: GgmlType>(
         let lhs = &lhs[row_idx * k..(row_idx + 1) * k];
         T::VecDotType::from_float(lhs, lhs_b)?
     }
-    let lhs_b = lhs_b.as_slice();
-    T::matmul(lhs_b, rhs_t, dst, m, n, k)?;
-    Ok(())
+    Ok(lhs_b)
 }
 
 impl GgmlType for f32 {

--- a/xn-core/src/quantized/mod.rs
+++ b/xn-core/src/quantized/mod.rs
@@ -314,6 +314,7 @@ impl QTensor {
         self.storage.data()
     }
 
+    #[tracing::instrument(name = "qmatmul-t", skip_all)]
     pub fn matmul_t(&self, mkn: (usize, usize, usize), lhs: &[f32], dst: &mut [f32]) -> Result<()> {
         match &self.storage {
             QStorage::Cpu(storage) => storage.matmul_t(mkn, lhs, dst),
@@ -330,6 +331,7 @@ impl crate::ModuleT for QLinear {
     type T = f32;
     type B = crate::CpuDevice;
 
+    #[tracing::instrument(name = "qlinear-forward", skip_all)]
     fn forward(
         &self,
         xs: &crate::Tensor<Self::T, Self::B>,


### PR DESCRIPTION
## Instrument the quantized GEMM paths
matmul_with_t carries a tracing span; none of the quantized matmuls did, so every quantized
linear was a blank gap in a chrome trace. Adds `#[tracing::instrument(skip_all)]` at the
equivalent entry points, with explicit span names so they don't collide with the f32
matmul_t/forward spans.

CPU (ggml Q4_0/Q8_0/…): qlinear-forward (the ModuleT entry Q::LinearQ resolves to),
qmatmul-t, q-matmul, and the two dispatch targets q-matmul-q8-0-sgemm / q-matmul-by-row,
so a shape's actual path is visible. The f32→block quantization of the activations moves out of
k_quants::matmul into quantize_lhs (q-matmul-quantize-lhs) so the copy/quantize cost is
separated from the kernel, a pure extraction, same logic and order.

CUDA FP8: fp8-linear-forward, fp8-matmul-t, fp8-quantize, fp8-quantize-per-token,
fp8-dequantize. The dequantize span matters because the unaligned-shape fallback in
Fp8Linear::forward silently drops to a bf16 matmul.
