### PR TITLE
Feature/fused cpu sdpa decode

### DIFF
--- a/xn-core/examples/sdpa_decode_bench.rs
+++ b/xn-core/examples/sdpa_decode_bench.rs
@@ -1,0 +1,123 @@
+// Per-call latency of single-query attention (autoregressive decode), fused vs composed.
+//
+// The composed variant is the transpose/matmul/softmax sequence a caller writes today; the
+// fused variant is `Tensor::sdpa_decode`. Both read the same operands: a query of one position
+// and a kv cache narrowed to its filled prefix, in the (b, pos, head, dim) layout the cache is
+// written in.
+//
+// Run with RAYON_NUM_THREADS=1 and with default threads.
+use xn::Result;
+
+type Tensor = xn::Tensor<f32, xn::CpuDevice>;
+
+/// Time one closure: `rounds` interleaved samples, keeping the minimum. The two variants are
+/// sampled alternately by the caller so that any drift (thermal, scheduler) hits both equally,
+/// and the minimum is what the machine actually does when nothing else interferes.
+fn sample<F: FnMut() -> Result<()>>(iters: usize, mut f: F) -> Result<f64> {
+    let start = std::time::Instant::now();
+    for _ in 0..iters {
+        f()?;
+    }
+    Ok(start.elapsed().as_secs_f64() / iters as f64)
+}
+
+fn bench<A: FnMut() -> Result<()>, B: FnMut() -> Result<()>>(
+    mut a: A,
+    mut b: B,
+) -> Result<(f64, f64)> {
+    for _ in 0..50 {
+        a()?;
+        b()?;
+    }
+    // Pick the iteration count from a pilot sample so every case gets ~20ms per round
+    // regardless of whether a call costs 1us or 100us.
+    let pilot = sample(20, &mut a)?;
+    let iters = ((0.02 / pilot) as usize).clamp(20, 20_000);
+    let (mut ta, mut tb) = (f64::INFINITY, f64::INFINITY);
+    for _ in 0..9 {
+        ta = ta.min(sample(iters, &mut a)?);
+        tb = tb.min(sample(iters, &mut b)?);
+    }
+    Ok((ta, tb))
+}
+
+/// What a caller writes without the fused op.
+fn composed(
+    q: &Tensor,
+    k: &xn::TensorView<f32, xn::CpuDevice>,
+    v: &xn::TensorView<f32, xn::CpuDevice>,
+    mask: Option<&Tensor>,
+    scale: f32,
+    b: usize,
+    hd: usize,
+) -> Result<Tensor> {
+    let qt = xn::TensorView::from(q).transpose(1, 2)?;
+    let kt = k.transpose(1, 2)?;
+    let vt = v.transpose(1, 2)?;
+    let attn = qt.matmul_t(&kt)?.scale(scale)?;
+    let attn = match mask {
+        Some(m) => attn.broadcast_add(m)?,
+        None => attn,
+    };
+    let attn = attn.softmax()?;
+    attn.matmul(&vt)?.transpose(1, 2)?.reshape((b, 1, hd))?.contiguous()
+}
+
+fn case(name: &str, b: usize, h: usize, d: usize, kv: usize, masked: bool) -> Result<()> {
+    let dev = xn::CPU;
+    // Allocate the cache at its full capacity and use the filled prefix, as decode does.
+    let cache_kv = kv.next_power_of_two().max(kv + 64);
+    let q = Tensor::zeros((b, 1, h, d), &dev)?;
+    q.rand_uniform_(-1.0, 1.0)?;
+    let kc = Tensor::zeros((b, cache_kv, h, d), &dev)?;
+    kc.rand_uniform_(-1.0, 1.0)?;
+    let vc = Tensor::zeros((b, cache_kv, h, d), &dev)?;
+    vc.rand_uniform_(-1.0, 1.0)?;
+    let k = kc.narrow(1, 0..kv)?;
+    let v = vc.narrow(1, 0..kv)?;
+    let scale = 1.0 / (d as f32).sqrt();
+    // Sliding-window style: keep the most recent half of the context.
+    let mask = if masked {
+        let cut = kv / 2;
+        Some(Tensor::from_vec(
+            (0..kv).map(|j| if j < cut { f32::NEG_INFINITY } else { 0.0 }).collect(),
+            (1, 1, 1, kv),
+            &dev,
+        )?)
+    } else {
+        None
+    };
+
+    let (c, f) = bench(
+        || composed(&q, &k, &v, mask.as_ref(), scale, b, h * d).map(|_| ()),
+        || q.sdpa_decode(&k, &v, mask.as_ref(), scale).map(|_| ()),
+    )?;
+    println!("{name:<38} {:>9.2} {:>9.2} {:>8.2}x", c * 1e6, f * 1e6, c / f);
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    println!("rayon threads: {}", rayon::current_num_threads());
+    println!("{:<38} {:>9} {:>9} {:>9}", "case (b,h,d,kv)", "composed", "fused", "speedup");
+    println!("{:-<68}", "");
+
+    // Real decode shapes from the models in this repo.
+    case("mimi transformer   1,8,64,250", 1, 8, 64, 250, false)?;
+    case("moshi lm           1,16,128,750", 1, 16, 128, 750, false)?;
+    case("moshi lm masked    1,16,128,750", 1, 16, 128, 750, true)?;
+    case("depformer          1,8,128,750", 1, 8, 128, 750, false)?;
+    case("moshi lm (32h)     1,32,64,375", 1, 32, 64, 375, false)?;
+    println!();
+
+    // Context sweep at one shape, to separate fixed overhead from per-kv work.
+    for kv in [1usize, 8, 32, 128, 512, 2048] {
+        case(&format!("ctx sweep          1,16,128,{kv}"), 1, 16, 128, kv, false)?;
+    }
+    println!();
+
+    // Batched decode.
+    for b in [2usize, 8, 32] {
+        case(&format!("batched            {b},16,128,750"), b, 16, 128, 750, false)?;
+    }
+    Ok(())
+}

--- a/xn-core/src/backend.rs
+++ b/xn-core/src/backend.rs
@@ -329,4 +329,44 @@ pub trait Backend: Sized + Clone + 'static + Sync + Send + std::fmt::Debug {
         output_padding: usize,
         groups: usize,
     ) -> Result<()>;
+
+    /// Whether this backend implements [`Backend::sdpa_decode`]. When false, callers compose
+    /// the operation from transpose/matmul/softmax instead.
+    const FUSED_SDPA_DECODE: bool = false;
+
+    /// Largest head dim [`Backend::sdpa_decode`] accepts. Callers fall back to the composed
+    /// form above it, so a backend may cap this at whatever its kernel is sized for.
+    const SDPA_MAX_HEAD_DIM: usize = 0;
+
+    /// Fused scaled-dot-product attention for a single query position, i.e. one step of
+    /// autoregressive decode.
+    ///
+    /// Operands keep the `(batch, pos, head, dim)` layout the attention cache is written in,
+    /// with `dim` innermost and contiguous, so no transposes are needed:
+    ///   `q[q_off + bi * h * d + hh * d + i]`
+    ///   `k[k_off + bi * kv_batch_stride + j * h * d + hh * d + i]` (same for `v`)
+    /// `dst` is contiguous `(b, h * d)`.
+    ///
+    /// `mask`, when given, is `kv` contiguous additive terms applied to every head and batch
+    /// (`0` to keep a position, `-inf` to drop it).
+    ///
+    /// Fusing matters here because the composed form is a batch of `h` tiny matmuls per
+    /// projection plus a separate softmax pass, which is dominated by per-call overhead rather
+    /// than arithmetic.
+    #[allow(clippy::too_many_arguments)]
+    fn sdpa_decode<T: crate::WithDTypeF>(
+        _dst: &mut Self::Storage<T>,
+        _q: (&Self::Storage<T>, usize),
+        _k: (&Self::Storage<T>, usize),
+        _v: (&Self::Storage<T>, usize),
+        _mask: Option<(&Self::Storage<T>, usize)>,
+        _kv_batch_stride: usize,
+        _b: usize,
+        _h: usize,
+        _d: usize,
+        _kv: usize,
+        _scale: f32,
+    ) -> Result<()> {
+        crate::bail!("sdpa_decode is not implemented for this backend")
+    }
 }

--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -1195,6 +1195,93 @@ impl crate::Backend for crate::CpuDevice {
         }
     }
 
+    const FUSED_SDPA_DECODE: bool = true;
+    const SDPA_MAX_HEAD_DIM: usize = CPU_SDPA_MAX_HEAD_DIM;
+
+    #[allow(clippy::too_many_arguments)]
+    fn sdpa_decode<T: WithDTypeF>(
+        dst: &mut Self::Storage<T>,
+        (q, q_off): (&Self::Storage<T>, usize),
+        (k, k_off): (&Self::Storage<T>, usize),
+        (v, v_off): (&Self::Storage<T>, usize),
+        mask: Option<(&Self::Storage<T>, usize)>,
+        kv_batch_stride: usize,
+        b: usize,
+        h: usize,
+        d: usize,
+        kv: usize,
+        scale: f32,
+    ) -> Result<()> {
+        if d > CPU_SDPA_MAX_HEAD_DIM {
+            crate::bail!("sdpa_decode: head dim {d} exceeds {CPU_SDPA_MAX_HEAD_DIM}")
+        }
+        if kv == 0 {
+            crate::bail!("sdpa_decode: empty kv")
+        }
+        let hd = h * d;
+        // One (batch, head) pair per unit of work; each owns a disjoint `d`-wide slice of dst.
+        //
+        // Streaming ("online") softmax: carry a running max, denominator and weighted sum so
+        // that no kv-sized score buffer is needed and a single pass over k and v suffices,
+        // while staying as numerically stable as a two-pass max-subtracted softmax.
+        let head = |idx: usize, out: &mut [T]| {
+            let bi = idx / h;
+            let hh = idx % h;
+            let qo = q_off + bi * hd + hh * d;
+            let kb = k_off + bi * kv_batch_stride + hh * d;
+            let vb = v_off + bi * kv_batch_stride + hh * d;
+            let qrow = &q[qo..qo + d];
+            let mut acc = [0f32; CPU_SDPA_MAX_HEAD_DIM];
+            let acc = &mut acc[..d];
+            let mut max = f32::NEG_INFINITY;
+            let mut denom = 0f32;
+            for j in 0..kv {
+                let ko = kb + j * hd;
+                let krow = &k[ko..ko + d];
+                let mut s = 0f32;
+                for (qq, kk) in qrow.iter().zip(krow.iter()) {
+                    s += <T as WithDTypeF>::to_f32(*qq) * <T as WithDTypeF>::to_f32(*kk);
+                }
+                s *= scale;
+                if let Some((m, m_off)) = mask {
+                    s += <T as WithDTypeF>::to_f32(m[m_off + j]);
+                }
+                if s == f32::NEG_INFINITY {
+                    // Fully masked: contributes nothing to the sum or the denominator. Skipping
+                    // it also keeps the running max finite, which `exp(max - s)` relies on.
+                    continue;
+                }
+                if s > max {
+                    // Rebase the running totals onto the new maximum. On the first step
+                    // `max` is -inf, so this correctly zeroes them.
+                    let c = (max - s).exp();
+                    denom *= c;
+                    for a in acc.iter_mut() {
+                        *a *= c;
+                    }
+                    max = s;
+                }
+                let p = (s - max).exp();
+                denom += p;
+                let vo = vb + j * hd;
+                for (a, vv) in acc.iter_mut().zip(v[vo..vo + d].iter()) {
+                    *a += p * <T as WithDTypeF>::to_f32(*vv);
+                }
+            }
+            let inv = 1.0 / denom;
+            for (o, a) in out.iter_mut().zip(acc.iter()) {
+                *o = T::from_f32(*a * inv);
+            }
+        };
+        let dst = &mut dst[..b * hd];
+        if use_parallelism(b * h * kv * d) {
+            dst.par_chunks_mut(d).enumerate().for_each(|(i, o)| head(i, o));
+        } else {
+            dst.chunks_mut(d).enumerate().for_each(|(i, o)| head(i, o));
+        }
+        Ok(())
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn conv_transpose1d<T: WithDTypeF>(
         dst: &mut Self::Storage<T>,
@@ -1412,6 +1499,10 @@ fn reduce_arg<T: WithDType + Copy>(
         }
     }
 }
+
+/// Largest head dimension the fused attention kernel keeps its accumulator on the stack for.
+/// Well above any head dim in practice; callers fall back to the composed path beyond it.
+const CPU_SDPA_MAX_HEAD_DIM: usize = 256;
 
 /// Below this many elements, elementwise ops run serially: the rayon fork/join overhead
 /// (~10us) dwarfs the work itself.

--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -1238,8 +1238,25 @@ impl crate::Backend for crate::CpuDevice {
             for j in 0..kv {
                 let ko = kb + j * hd;
                 let krow = &k[ko..ko + d];
-                let mut s = 0f32;
-                for (qq, kk) in qrow.iter().zip(krow.iter()) {
+                // Independent partial sums, the same shape as `reduce_combine`: a single
+                // `s += q * k` accumulator is a serial dependency chain the compiler cannot
+                // reorder (float addition is not associative), which pins the dot product at
+                // one FMA per latency. Eight lanes -- two 4-wide f32 vectors -- let it both
+                // vectorize and keep several FMAs in flight; eight measured distinctly
+                // better than four here.
+                const LANES: usize = 8;
+                let mut lanes = [0f32; LANES];
+                // Head dims are multiples of 8 in practice, so these tails are normally empty.
+                let (q_chunks, q_rem) = qrow.as_chunks::<LANES>();
+                let (k_chunks, k_rem) = krow.as_chunks::<LANES>();
+                for (qc, kc) in q_chunks.iter().zip(k_chunks.iter()) {
+                    for l in 0..LANES {
+                        lanes[l] +=
+                            <T as WithDTypeF>::to_f32(qc[l]) * <T as WithDTypeF>::to_f32(kc[l]);
+                    }
+                }
+                let mut s: f32 = lanes.iter().sum();
+                for (qq, kk) in q_rem.iter().zip(k_rem.iter()) {
                     s += <T as WithDTypeF>::to_f32(*qq) * <T as WithDTypeF>::to_f32(*kk);
                 }
                 s *= scale;

--- a/xn-core/src/ops.rs
+++ b/xn-core/src/ops.rs
@@ -273,6 +273,128 @@ impl<T: WithDTypeF, B: Backend> Tensor<T, B> {
         Ok(result)
     }
 
+    /// Scaled-dot-product attention for a single query position (autoregressive decode).
+    ///
+    /// `self` is the query, shape `(b, 1, h, d)`. `k` and `v` are the accumulated keys and
+    /// values, shape `(b, kv, h, d)` — the layout an attention cache is written in, so callers
+    /// need no transposes. Returns `(b, 1, h * d)`, ready for the output projection.
+    ///
+    /// Backends advertising [`Backend::FUSED_SDPA_DECODE`] run this as one pass; otherwise it
+    /// is composed from transpose/matmul/softmax, which is what the caller would have written
+    /// by hand.
+    #[tracing::instrument(name = "sdpa-decode", skip_all)]
+    pub fn sdpa_decode(
+        &self,
+        k: &crate::TensorView<T, B>,
+        v: &crate::TensorView<T, B>,
+        mask: Option<&Self>,
+        scale: f32,
+    ) -> Result<Self> {
+        let qd = self.shape.dims();
+        if qd.len() != 4 || qd[1] != 1 {
+            crate::bail!("sdpa_decode expects a (b, 1, h, d) query, got {:?}", self.shape)
+        }
+        let (b, h, d) = (qd[0], qd[2], qd[3]);
+        for (name, t) in [("k", k), ("v", v)] {
+            let td = t.dims();
+            if td.len() != 4 || td[0] != b || td[2] != h || td[3] != d {
+                crate::bail!(
+                    "sdpa_decode: {name} shape {:?} incompatible with q {:?}",
+                    t.shape(),
+                    self.shape
+                )
+            }
+        }
+        let kv = k.dims()[1];
+        if v.dims()[1] != kv {
+            crate::bail!("sdpa_decode: k has {kv} positions but v has {}", v.dims()[1])
+        }
+
+        // The fused kernel addresses operands as (b, pos, head, dim) with `dim` innermost, so
+        // it applies only when the trailing dims are laid out that way. A cache narrowed to its
+        // filled prefix satisfies this even though it is shorter than its storage.
+        let hd = h * d;
+        let laid_out = |strides: &[usize], batch_stride: usize| {
+            strides[3] == 1 && strides[2] == d && strides[1] == hd && strides[0] == batch_stride
+        };
+        // The kernel takes one batch stride for both k and v, so they must agree on it.
+        let kv_batch_stride = k.strides()[0];
+        let q_ok = laid_out(&self.shape.stride_contiguous(), hd);
+        let k_ok = laid_out(k.strides(), kv_batch_stride);
+        let v_ok = laid_out(v.strides(), kv_batch_stride);
+
+        // A mask is applied per key position, broadcast over heads and batch, so it has to be
+        // exactly `kv` values with every leading dimension 1.
+        let mask_ok = match mask {
+            None => true,
+            Some(m) => {
+                m.shape.elem_count() == kv
+                    && *m.shape.dims().last().unwrap_or(&0) == kv
+                    && m.shape.is_contiguous(&m.shape.stride_contiguous())
+            }
+        };
+        if B::FUSED_SDPA_DECODE
+            && d <= B::SDPA_MAX_HEAD_DIM
+            && kv > 0
+            && q_ok
+            && k_ok
+            && v_ok
+            && mask_ok
+        {
+            let out: Tensor<T, B> =
+                unsafe { Tensor::alloc_uninit(crate::Shape::from((b, 1, hd)), self.device()) }?;
+            {
+                let qs = self.storage()?;
+                let (ks, k_off) = k.storage_and_offset()?;
+                let (vs, v_off) = v.storage_and_offset()?;
+                let mut os = out.storage_mut()?;
+                let ms = match mask {
+                    Some(m) => Some(m.storage()?),
+                    None => None,
+                };
+                B::sdpa_decode(
+                    &mut os,
+                    (&qs, 0),
+                    (&ks, k_off),
+                    (&vs, v_off),
+                    ms.as_deref().map(|m| (m, 0)),
+                    kv_batch_stride,
+                    b,
+                    h,
+                    d,
+                    kv,
+                    scale,
+                )?;
+            }
+            return Ok(out);
+        }
+
+        self.sdpa_composed(k, v, mask, scale, b, hd)
+    }
+
+    /// The transpose/matmul/softmax sequence a caller would otherwise write by hand. Used when
+    /// the backend has no fused kernel, or when the operands do not match the layout it needs.
+    fn sdpa_composed(
+        &self,
+        k: &crate::TensorView<T, B>,
+        v: &crate::TensorView<T, B>,
+        mask: Option<&Self>,
+        scale: f32,
+        b: usize,
+        hd: usize,
+    ) -> Result<Self> {
+        let q = crate::TensorView::from(self).transpose(1, 2)?;
+        let kt = k.transpose(1, 2)?;
+        let vt = v.transpose(1, 2)?;
+        let attn = q.matmul_t(&kt)?.scale(T::from_f32(scale))?;
+        let attn = match mask {
+            Some(m) => attn.broadcast_add(m)?,
+            None => attn,
+        };
+        let attn = attn.softmax()?;
+        attn.matmul(&vt)?.transpose(1, 2)?.reshape((b, 1, hd))?.contiguous()
+    }
+
     #[tracing::instrument(skip_all)]
     pub fn rope_i(&self, cos: &Self, sin: &Self, pos: usize) -> Result<Self> {
         let result = unsafe { Tensor::alloc_uninit(self.shape.clone(), self.device()) }?;

--- a/xn-core/tests/tensor_tests.rs
+++ b/xn-core/tests/tensor_tests.rs
@@ -1065,6 +1065,96 @@ fn check_grouped_matches_per_group(
     Ok(())
 }
 
+// -----------------------------------------------------------------------------
+// Fused single-query attention (sdpa_decode)
+// -----------------------------------------------------------------------------
+
+/// Reference: the transpose/matmul/softmax sequence a caller would otherwise write.
+fn sdpa_reference(
+    q: &Tensor<f32, xn::CpuDevice>,
+    k: &xn::TensorView<f32, xn::CpuDevice>,
+    v: &xn::TensorView<f32, xn::CpuDevice>,
+    mask: Option<&Tensor<f32, xn::CpuDevice>>,
+    scale: f32,
+) -> Result<Vec<f32>> {
+    let d = q.dims()[3];
+    let (b, h) = (q.dims()[0], q.dims()[2]);
+    let qt = xn::TensorView::from(q).transpose(1, 2)?;
+    let kt = k.transpose(1, 2)?;
+    let vt = v.transpose(1, 2)?;
+    let attn = qt.matmul_t(&kt)?.scale(scale)?;
+    let attn = match mask {
+        Some(m) => attn.broadcast_add(m)?,
+        None => attn,
+    };
+    let attn = attn.softmax()?;
+    attn.matmul(&vt)?.transpose(1, 2)?.reshape((b, 1, h * d))?.contiguous()?.to_vec()
+}
+
+fn check_sdpa(b: usize, h: usize, d: usize, kv: usize, cache_kv: usize) -> Result<()> {
+    check_sdpa_masked(b, h, d, kv, cache_kv, false)?;
+    check_sdpa_masked(b, h, d, kv, cache_kv, true)
+}
+
+fn check_sdpa_masked(
+    b: usize,
+    h: usize,
+    d: usize,
+    kv: usize,
+    cache_kv: usize,
+    masked: bool,
+) -> Result<()> {
+    let dev = &xn::CPU;
+    let mut seed = 0x2545_f491u32;
+    let mut rnd = || {
+        seed ^= seed << 13;
+        seed ^= seed >> 17;
+        seed ^= seed << 5;
+        (seed as f32 / u32::MAX as f32) - 0.5
+    };
+    let q: Tensor<f32, _> =
+        Tensor::from_vec((0..b * h * d).map(|_| rnd()).collect(), (b, 1, h, d), dev)?;
+    // Allocate the cache at `cache_kv` and use only its first `kv` positions, so the operands
+    // are a contiguous prefix of a longer storage -- the real decode situation.
+    let kc: Tensor<f32, _> = Tensor::from_vec(
+        (0..b * cache_kv * h * d).map(|_| rnd()).collect(),
+        (b, cache_kv, h, d),
+        dev,
+    )?;
+    let vc: Tensor<f32, _> = Tensor::from_vec(
+        (0..b * cache_kv * h * d).map(|_| rnd()).collect(),
+        (b, cache_kv, h, d),
+        dev,
+    )?;
+    let k = kc.narrow(1, 0..kv)?;
+    let v = vc.narrow(1, 0..kv)?;
+    let scale = 1.0 / (d as f32).sqrt();
+    // Sliding-window style: drop the oldest half of the context.
+    let mask: Option<Tensor<f32, _>> = if masked {
+        let cut = kv / 2;
+        Some(Tensor::from_vec(
+            (0..kv).map(|j| if j < cut { f32::NEG_INFINITY } else { 0.0 }).collect(),
+            (1, 1, 1, kv),
+            dev,
+        )?)
+    } else {
+        None
+    };
+
+    let got = q.sdpa_decode(&k, &v, mask.as_ref(), scale)?;
+    assert_eq!(got.dims(), &[b, 1, h * d]);
+    let got = got.to_vec()?;
+    let want = sdpa_reference(&q, &k, &v, mask.as_ref(), scale)?;
+    assert_eq!(got.len(), want.len());
+    for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+        assert!(
+            (g - w).abs() <= 1e-5 * w.abs().max(1.0),
+            "b={b} h={h} d={d} kv={kv}: index {i}: got {g}, want {w}"
+        );
+    }
+    Ok(())
+}
+
 #[test]
 fn test_conv_transpose1d_depthwise_cpu() -> Result<()> {
     // groups == in_channels == out_channels: the depthwise branch.
@@ -1133,6 +1223,32 @@ fn test_conv_transpose1d_output_padding_appends_zeros_cpu() -> Result<()> {
             assert_eq!(ext_v[c * (base_len + q) + i], 0., "ch {c} tail index {i} not zero");
         }
     }
+    Ok(())
+}
+
+#[test]
+fn test_sdpa_decode_matches_composed_cpu() -> Result<()> {
+    // exact-size cache (no prefix), then genuine prefixes of a longer cache
+    check_sdpa(1, 12, 64, 7, 7)?;
+    check_sdpa(1, 12, 64, 200, 4096)?;
+    check_sdpa(1, 1, 8, 1, 16)?;
+    check_sdpa(2, 4, 16, 33, 64)?;
+    check_sdpa(1, 8, 64, 1, 4096)
+}
+
+#[test]
+fn test_sdpa_decode_rejects_bad_shapes_cpu() -> Result<()> {
+    let dev = &xn::CPU;
+    let q: Tensor<f32, _> = Tensor::full(0.5, (1, 1, 4, 8), dev)?;
+    let kc: Tensor<f32, _> = Tensor::full(0.25, (1, 5, 4, 8), dev)?;
+    let bad: Tensor<f32, _> = Tensor::full(0.25, (1, 5, 4, 16), dev)?;
+    let k = kc.narrow(1, 0..5)?;
+    let badv = bad.narrow(1, 0..5)?;
+    // mismatched head dim between q and v
+    assert!(q.sdpa_decode(&k, &badv, None, 1.0).is_err());
+    // a query with more than one position is not a decode step
+    let q2: Tensor<f32, _> = Tensor::full(0.5, (1, 2, 4, 8), dev)?;
+    assert!(q2.sdpa_decode(&k, &k, None, 1.0).is_err());
     Ok(())
 }
 


### PR DESCRIPTION
# Fused single-query attention (`sdpa_decode`) on the CPU backend

## Summary

Adds `Tensor::sdpa_decode`, one step of autoregressive attention, with a fused CPU kernel
behind a new `Backend::FUSED_SDPA_DECODE` capability flag. On the decode shapes the models in
this repo use it is **2.6–4.9x faster** than the transpose/matmul/softmax sequence it replaces
on a 10-thread pool, and **1.2–1.8x** single-threaded.

The composed form is a batch of `h` tiny matmuls per projection plus a separate softmax pass,
seven tensor ops, each with its own allocation, dispatch and rayon fork/join, over operands that
are a few hundred KB. At `kv = 1` those seven ops cost 35us and the arithmetic costs ~0.1us.
That fixed overhead, is what gets removed here.

**Nothing calls it yet.** It's been tested with phonon/xn-ptts but left for later integration PRs for now.

## What it does

```rust
// q: (b, 1, h, d)   k, v: (b, kv, h, d)   mask: Option<(.., kv)>  ->  (b, 1, h * d)
let out = q.sdpa_decode(&k_cache.narrow(1, 0..kv)?, &v_cache.narrow(1, 0..kv)?, mask, scale)?;
```

Operands stay in the `(batch, pos, head, dim)` layout the attention cache is already written in,
so the caller needs no transposes, and the result comes back as `(b, 1, h * d)`, ready for the
output projection.

Two things worth calling out in review:

**Streaming ("online") softmax.** The kernel carries a running max, denominator and weighted
sum, so it walks `k` and `v` exactly once per `(batch, head)` pair. No `kv`-sized score buffer is
allocated and there is no second pass, while numerical stability matches a two-pass
max-subtracted softmax. A fully-masked position (`-inf`) is skipped rather than exponentiated,
which also keeps the running max finite.

**The fast path is gated on layout, not just on the backend.** `sdpa_decode` checks that the
trailing dims really are `(pos, head, dim)` with `dim` innermost and that `k` and `v` agree on
their batch stride; a cache narrowed to its filled prefix satisfies this even though it is
shorter than its storage. Anything else, an unsupported backend, a head dim above
`B::SDPA_MAX_HEAD_DIM`, a strided view, a mask that is not one value per key position, falls
through to `sdpa_composed`, which is exactly the sequence a caller writes today. The
capability flag defaults to `false`, so no other backend needs a change.

## Benchmarks

`cargo run --release --example sdpa_decode_bench`, Apple M5 (4 P-cores + 6 E-cores), f32,
us per call. The harness samples the two variants alternately and keeps the minimum of nine
rounds, so drift hits both equally. Shapes are the real configs in this repo: mimi's transformer
(`h=8, d=64, ctx=250`), the moshi LM (`h=16, d=128, ctx=750`), its 32-head variant, and the
depformer.

### Default pool (10 threads)

| case (b, h, d, kv)            | composed | fused | speedup |
|-------------------------------|---------:|------:|--------:|
| mimi transformer 1,8,64,250   |    68.92 | 26.26 |  2.62x  |
| moshi lm 1,16,128,750         |   440.54 |137.45 |  3.21x  |
| moshi lm masked 1,16,128,750  |   458.69 | 94.12 |  4.87x  |
| depformer 1,8,128,750         |   246.14 | 81.47 |  3.02x  |
| moshi lm 32h 1,32,64,375      |   313.59 | 69.97 |  4.48x  |

### Single thread (`RAYON_NUM_THREADS=1`)

| case (b, h, d, kv)            | composed | fused | speedup |
|-------------------------------|---------:|------:|--------:|
| mimi transformer 1,8,64,250   |    38.66 | 22.07 |  1.75x  |
| moshi lm 1,16,128,750         |   370.88 |300.56 |  1.23x  |
| moshi lm masked 1,16,128,750  |   388.15 |213.38 |  1.82x  |
| depformer 1,8,128,750         |   181.44 |148.68 |  1.22x  |
| moshi lm 32h 1,32,64,375      |   215.60 |178.29 |  1.21x  |

The masked cases gain the most because a `-inf` position costs the fused kernel a compare and a
`continue`, while the composed path still materializes and exponentiates it.

### Context sweep (b=1, h=16, d=128), separating fixed overhead from per-kv work

| kv   | 10t composed | 10t fused | 10t | 1t composed | 1t fused |  1t  |
|-----:|-------------:|----------:|----:|------------:|---------:|-----:|
|    1 |        35.40 |      0.83 |42.5x|        8.21 |     0.75 |10.9x |
|    8 |        40.91 |      3.54 |11.6x|       10.90 |     3.55 | 3.1x |
|   32 |        55.32 |     24.91 | 2.2x|       21.04 |    12.23 | 1.7x |
|  128 |       134.44 |     33.16 | 4.1x|       67.40 |    48.98 | 1.4x |
|  512 |       347.29 |     83.06 | 4.2x|      249.61 |   200.29 | 1.2x |
| 2048 |      1373.59 |    581.98 | 2.4x|     1141.62 |  1553.08 | 0.7x |

The `kv = 1` column is the fixed cost being removed: seven dispatches and allocations against
one pass over 2K floats. The speedup then falls as real arithmetic starts to dominate.

### Batch sweep (h=16, d=128, kv=750)

| b  | 10t composed | 10t fused |  10t  | 1t composed | 1t fused |  1t  |
|---:|-------------:|----------:|------:|------------:|---------:|-----:|
|  2 |      1540.96 |    380.26 | 4.05x |     3213.96 |  1009.89 |3.18x |
|  8 |      5688.28 |   1819.36 | 3.13x |    14988.80 |  6683.36 |2.24x |
| 32 |     22523.02 |   7106.96 | 3.17x |    59303.03 | 27348.97 |2.17x |

## Known limits

- **Long single-threaded contexts.** At `kv = 2048` on one thread the fused kernel is 0.74x
  composed. The fused kernel reads `k` and `v` with a `h * d` stride between positions (8KB
  here), while the composed path pays a transpose to get contiguous operands and then hands
  `gemm` a stream it prefetches well. This is past the context of every model in the repo
  (mimi 250, moshi 750), so it is a real ceiling rather than a real regression, a blocked
  loop over positions would be the fix if it ever matters.
- **No GQA.** `k` and `v` must have the same head count as `q`. The models here all use
  `kv_repeat = 1`, so this covers them, but a grouped-query model would need the head index
  mapped through a repeat factor.
- **Head dim ≤ 256**, the size the on-stack accumulator is fixed at; above it the caller
  composes.

## Tests

Two new CPU tests, `+116` lines in `xn-core/tests/tensor_tests.rs`:

- `test_sdpa_decode_matches_composed_cpu`, pins the fused kernel against the composed sequence
  to 1e-5 relative, masked and unmasked, over five shapes. Four of them use a cache allocated
  larger than the filled prefix (e.g. 200 of 4096), which is the real decode situation and the
  case the layout gate exists for; `(1, 1, 8, 1, 16)` covers a single key position and
  `(2, 4, 16, 33, 64)` a batch with a non-power-of-two context.
- `test_sdpa_decode_rejects_bad_shapes_cpu`, a `q`/`v` head-dim mismatch and a multi-position
  query are errors, not silent wrong answers.