### PR TITLE
perf: run operators on a resident worker pool

### DIFF
--- a/xn-core/src/cpu_backend.rs
+++ b/xn-core/src/cpu_backend.rs
@@ -8,11 +8,11 @@ const USE_IM2COL_CONV1D: bool = true;
 const USE_COL2IM_CONV1D_TR: bool = true;
 
 /// Whether to use a parallel implementation for this many elements of work. The work must be
-/// large enough to amortize the rayon fork/join overhead, and the global pool must actually
-/// have more than one thread: with a single-thread pool (e.g. RAYON_NUM_THREADS=1) every
-/// parallel call would still pay a cross-thread job handoff for no benefit.
+/// large enough to amortize the dispatch, and the pool must actually have more than one
+/// participant: with a single-thread pool (e.g. RAYON_NUM_THREADS=1) every parallel call would
+/// still pay a handoff for no benefit.
 fn use_parallelism(work: usize) -> bool {
-    work >= ELEMWISE_PAR_THRESHOLD && rayon::current_num_threads() > 1
+    work >= ELEMWISE_PAR_THRESHOLD && crate::threadpool::size() > 1
 }
 
 fn copy_strided_2d<T: WithDType>(
@@ -78,10 +78,63 @@ fn gemm_<T: WithDType>(
 ) -> Result<()> {
     let lhs = &lhs[lhs_o..];
     let rhs = &rhs[rhs_o..];
+
+    // Column stripes, run on xn's own pool rather than letting `gemm` reach for rayon.
+    //
+    // Two pools would otherwise both be live inside a decode step -- this one for the f32
+    // matmuls and xn's for everything else -- and their idle workers spin against each other
+    // for cores. Splitting by output column is what `Parallelism::Rayon` does internally
+    // anyway; the cost is that each stripe re-packs the lhs panel, which is negligible at the
+    // batch sizes decode uses.
+    let nth = crate::threadpool::size();
+    // One stripe per participant. Measured against 0.25x, 0.5x, 2x and 4x that count: 1x and
+    // 2x tie, everything else is worse. Splitting the rows instead when the output is too
+    // narrow to stripe was also tried and nets nothing, so narrow outputs stay serial.
+    let stripes = if nth > 1 && n >= nth * 4 && m * n * k >= 1 << 14 { nth } else { 1 };
+
     for b_idx in 0..lhs_b {
         let dst = &mut dst[b_idx * m * n..(b_idx + 1) * m * n];
         let lhs = &lhs[b_idx * lhs_b_stride..];
         let rhs = &rhs[b_idx * rhs_b_stride..];
+        if stripes > 1 {
+            let dst_p = dst.as_mut_ptr() as usize;
+            let lhs_p = lhs.as_ptr() as usize;
+            let rhs_p = rhs.as_ptr() as usize;
+            crate::threadpool::par_units(stripes, |s| {
+                let per = n.div_ceil(stripes);
+                let n0 = (s * per).min(n);
+                let n1 = (n0 + per).min(n);
+                if n0 == n1 {
+                    return;
+                }
+                // SAFETY: stripes own disjoint output columns, and every offset stays inside
+                // the slices borrowed above, which outlive the dispatch.
+                unsafe {
+                    gemm::gemm(
+                        m,
+                        n1 - n0,
+                        k,
+                        (dst_p as *mut T).add(n0 * dst_cs),
+                        dst_cs as isize,
+                        dst_rs as isize,
+                        false,
+                        lhs_p as *const T,
+                        lhs_cs as isize,
+                        lhs_rs as isize,
+                        (rhs_p as *const T).add(n0 * rhs_cs),
+                        rhs_cs as isize,
+                        rhs_rs as isize,
+                        T::zero(),
+                        T::one(),
+                        false,
+                        false,
+                        false,
+                        gemm::Parallelism::None,
+                    )
+                }
+            });
+            continue;
+        }
         unsafe {
             gemm::gemm(
                 /* m: usize = */ m,
@@ -102,7 +155,7 @@ fn gemm_<T: WithDType>(
                 /* conj_dst: bool = */ false,
                 /* conj_lhs: bool = */ false,
                 /* conj_rhs: bool = */ false,
-                gemm::Parallelism::Rayon(crate::get_num_threads()),
+                gemm::Parallelism::None,
             )
         }
     }
@@ -939,9 +992,9 @@ impl crate::Backend for crate::CpuDevice {
             }
         };
         if use_parallelism(d * dim_m1) {
-            src.par_chunks(dim_m1)
-                .zip(dst.par_chunks_mut(dim_m1))
-                .for_each(|(s, d)| softmax_row(s, d));
+            crate::threadpool::par_chunks_zip(dst, dim_m1, src, dim_m1, |_, d, s| {
+                softmax_row(s, d)
+            });
         } else {
             src.chunks(dim_m1).zip(dst.chunks_mut(dim_m1)).for_each(|(s, d)| softmax_row(s, d));
         }
@@ -958,7 +1011,7 @@ impl crate::Backend for crate::CpuDevice {
     ) -> Result<()> {
         let src = &src[..d * dim_m1];
         let dst = &mut dst[..d * dim_m1];
-        src.par_chunks(dim_m1).zip(dst.par_chunks_mut(dim_m1)).for_each(|(src, dst)| {
+        crate::threadpool::par_chunks_zip(dst, dim_m1, src, dim_m1, |_, dst, src| {
             let sum2 = src.iter().map(|&v| v.to_f32() * v.to_f32()).sum::<f32>();
             let m = (sum2 / dim_m1 as f32 + eps).sqrt();
             for ((d, s), alpha) in dst.iter_mut().zip(src.iter()).zip(alpha) {
@@ -982,7 +1035,7 @@ impl crate::Backend for crate::CpuDevice {
         let dst = &mut dst[..d * dim_m1];
         let weight = &weight[..dim_m1];
         let bias = &bias[..dim_m1];
-        src.par_chunks(dim_m1).zip(dst.par_chunks_mut(dim_m1)).for_each(|(src, dst)| {
+        crate::threadpool::par_chunks_zip(dst, dim_m1, src, dim_m1, |_, dst, src| {
             // Compute mean
             let sum: f32 = src.iter().map(|&v| v.to_f32()).sum();
             let mean = sum / dim_m1 as f32;
@@ -1292,7 +1345,7 @@ impl crate::Backend for crate::CpuDevice {
         };
         let dst = &mut dst[..b * hd];
         if use_parallelism(b * h * kv * d) {
-            dst.par_chunks_mut(d).enumerate().for_each(|(i, o)| head(i, o));
+            crate::threadpool::par_chunks_mut(dst, d, |i, o| head(i, o));
         } else {
             dst.chunks_mut(d).enumerate().for_each(|(i, o)| head(i, o));
         }
@@ -1539,8 +1592,12 @@ where
             f(d, *s);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
-            |(dst, src)| {
+        crate::threadpool::par_chunks_zip(
+            dst,
+            ELEMWISE_CHUNK,
+            src,
+            ELEMWISE_CHUNK,
+            |_, dst, src| {
                 for (d, s) in dst.iter_mut().zip(src) {
                     f(d, *s);
                 }
@@ -1560,7 +1617,7 @@ where
             f(d);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).for_each(|dst| {
+        crate::threadpool::par_chunks_mut(dst, ELEMWISE_CHUNK, |_, dst| {
             for d in dst.iter_mut() {
                 f(d);
             }
@@ -1579,8 +1636,12 @@ where
             *d = f(*s);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK).zip(src.par_chunks(ELEMWISE_CHUNK)).for_each(
-            |(dst, src)| {
+        crate::threadpool::par_chunks_zip(
+            dst,
+            ELEMWISE_CHUNK,
+            src,
+            ELEMWISE_CHUNK,
+            |_, dst, src| {
                 for (d, s) in dst.iter_mut().zip(src) {
                     *d = f(*s);
                 }
@@ -1600,13 +1661,20 @@ where
             *d = f(*l, *r);
         }
     } else {
-        dst.par_chunks_mut(ELEMWISE_CHUNK)
-            .zip(lhs.par_chunks(ELEMWISE_CHUNK).zip(rhs.par_chunks(ELEMWISE_CHUNK)))
-            .for_each(|(dst, (lhs, rhs))| {
+        crate::threadpool::par_chunks_zip(
+            dst,
+            ELEMWISE_CHUNK,
+            lhs,
+            ELEMWISE_CHUNK,
+            |c, dst, lhs| {
+                // `rhs` is chunked the same way, so the piece is fixed by the chunk index.
+                let start = c * ELEMWISE_CHUNK;
+                let rhs = &rhs[start..(start + dst.len()).min(rhs.len())];
                 for ((d, l), r) in dst.iter_mut().zip(lhs).zip(rhs) {
                     *d = f(*l, *r);
                 }
-            });
+            },
+        );
     }
 }
 
@@ -1652,7 +1720,7 @@ fn im2col1d<T: WithDTypeF>(
         }
     };
     if use_parallelism(batch * l_out * k) {
-        dst.par_chunks_mut(k).enumerate().for_each(|(bl, dst_row)| fill_row(bl, dst_row));
+        crate::threadpool::par_chunks_mut(&mut dst, k, |bl, dst_row| fill_row(bl, dst_row));
     } else {
         dst.chunks_mut(k).enumerate().for_each(|(bl, dst_row)| fill_row(bl, dst_row));
     }
@@ -1777,7 +1845,7 @@ fn col2im1d<T: WithDTypeF>(
         }
     };
     if use_parallelism(dst.len().max(col.len())) {
-        dst.par_chunks_mut(l_out).enumerate().for_each(|(bc, dst)| accumulate(bc, dst));
+        crate::threadpool::par_chunks_mut(dst, l_out, |bc, dst| accumulate(bc, dst));
     } else {
         dst.chunks_mut(l_out).enumerate().for_each(|(bc, dst)| accumulate(bc, dst));
     }
@@ -1875,7 +1943,7 @@ fn conv_transpose1d_direct<T: WithDTypeF>(
 
     let dst = &mut dst[..batch * out_channels * out_length];
     if use_parallelism(batch * out_channels * kernel_size * length) {
-        dst.par_chunks_mut(out_length).enumerate().for_each(|(bc, d)| accumulate(bc, d));
+        crate::threadpool::par_chunks_mut(dst, out_length, |bc, d| accumulate(bc, d));
     } else {
         dst.chunks_mut(out_length).enumerate().for_each(|(bc, d)| accumulate(bc, d));
     }

--- a/xn-core/src/lib.rs
+++ b/xn-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod shape;
 pub mod streaming;
 pub mod tensor;
 pub mod tensor_view;
+pub mod threadpool;
 pub mod utils;
 
 pub use backend::Backend;

--- a/xn-core/src/quantized/k_quants.rs
+++ b/xn-core/src/quantized/k_quants.rs
@@ -738,17 +738,11 @@ fn matmul_q8_0_sgemm(
     let a_addr = rhs_t.as_ptr() as usize;
     let b_addr = lhs_b.as_ptr() as usize;
     let c_addr = dst.as_mut_ptr() as usize;
-    // Gating the fan-out on a work threshold was measured and rejected: it helps only when the
-    // pool is shared with another busy thread, and costs ~3.4% otherwise. With a single-worker
-    // pool there is still nothing to fan out to, so call the kernel directly and skip the join.
-    let nth = rayon::current_num_threads().max(1);
-    if nth == 1 {
-        // SAFETY: the sole worker's tile range covers the output exactly once, so nothing
-        // aliases. Bounds were checked above against the slice lengths.
-        unsafe { sgemm_q8_0_tile(a_addr, b_addr, c_addr, n, m, k_blocks, 0, 1) };
-        return Ok(());
-    }
-    (0..nth).into_par_iter().for_each(|ith| {
+    // A single-participant pool runs the closure inline, so a one-worker build still pays no
+    // join here and needs no special case. Gating the fan-out on a work threshold was measured
+    // and rejected: it helps only when the pool is shared with another busy thread, and costs
+    // ~3.4% otherwise.
+    crate::threadpool::dispatch(|ith, nth| {
         // SAFETY: tile assignments are disjoint across `ith` values, so
         // writes through `c_addr` do not alias. Bounds were checked
         // above against the slice lengths.
@@ -759,9 +753,8 @@ fn matmul_q8_0_sgemm(
 
 // Run the `ith` of `nth` tile ranges on whichever sgemm kernel this build has.
 //
-// Both the serial and the fanned-out paths go through here, so a target can never end up at a
-// call site whose `cfg` arms it fails to match -- which would leave `dst` untouched and return
-// `Ok`. The three arms are exhaustive over the `cfg` on `matmul_q8_0_sgemm` itself.
+// The three arms are exhaustive over the `cfg` on `matmul_q8_0_sgemm` itself, so a target can
+// never fall through all of them, leave `dst` untouched and still return `Ok`.
 //
 // # Safety
 // `a` and `b` must address at least `n * k_blocks` and `m * k_blocks` `BlockQ8_0`s, `c` at

--- a/xn-core/src/quantized/repack.rs
+++ b/xn-core/src/quantized/repack.rs
@@ -21,7 +21,6 @@ use super::GgmlDType;
 use super::k_quants::{BlockQ8_0, GgmlType, QK8_0};
 use crate::Result;
 use half::f16;
-use rayon::prelude::*;
 use std::borrow::Cow;
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
@@ -249,7 +248,6 @@ fn matmul_interleaved(
     kb: usize,
 ) {
     let ngroups = n / NCOLS;
-    let nth = rayon::current_num_threads().max(1);
 
     // Each worker owns a contiguous run of column groups, so it walks one unbroken span of the
     // weight buffer and writes a disjoint set of dst columns.
@@ -263,13 +261,14 @@ fn matmul_interleaved(
         kb,
     };
 
-    if nth == 1 || ngroups == 1 {
-        // SAFETY: single worker, so the one range covers the output exactly once.
+    if ngroups == 1 {
+        // SAFETY: one range, covering the output exactly once.
         unsafe { job.run(0, ngroups) };
         return;
     }
-    let duty = ngroups.div_ceil(nth);
-    (0..nth).into_par_iter().for_each(|ith| {
+    // A single-participant pool runs this inline, so a one-worker build pays no join.
+    crate::threadpool::dispatch(|ith, nth| {
+        let duty = ngroups.div_ceil(nth);
         let g0 = (duty * ith).min(ngroups);
         let g1 = (g0 + duty).min(ngroups);
         if g0 == g1 {
@@ -281,7 +280,7 @@ fn matmul_interleaved(
     });
 }
 
-/// One matmul's operands, as addresses so the rayon closure needs no wrapper type.
+/// One matmul's operands, as addresses so the dispatched closure needs no wrapper type.
 #[derive(Clone, Copy)]
 struct Job {
     w: usize,

--- a/xn-core/src/threadpool.rs
+++ b/xn-core/src/threadpool.rs
@@ -1,0 +1,412 @@
+//! A persistent worker pool for fan-out inside a single operator.
+//!
+//! Batch-1 decode is a long sequence of individually tiny kernels: a 12-layer backbone issues
+//! roughly fifty quantized matmuls per token, each a few tens of microseconds. Handing each one
+//! to `rayon::join`-style work stealing means paying a fork/join per kernel -- measured on an M5
+//! at about 10 us with 3 workers and 34 us with 8, against kernels that take 25-70 us. That is
+//! why adding threads past three makes decode *slower*: the dispatch grows faster than the work
+//! shrinks.
+//!
+//! ggml avoids it by never dispatching per operator. `ggml_graph_compute_kickoff` wakes the pool
+//! once for a whole graph and the workers then walk the node list together, meeting at
+//! `ggml_barrier` between nodes -- two atomics and a `yield` spin, comfortably under a
+//! microsecond. xn is eager and has no graph to hand a pool, so this module takes the other half
+//! of the idea: the workers are permanent and park only when the stream goes quiet, so a
+//! dispatch is a sequence-number bump plus a spin, not a task submission.
+//!
+//! [`dispatch`] is deliberately shaped like the `ith`/`nth` split the kernels already use, so
+//! call sites change by one line.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex, OnceLock};
+
+/// Iterations of `spin_loop` a worker burns before parking, overridable with `XN_SPIN_BUDGET`.
+///
+/// The budget has to bridge the gap between two consecutive parallel operators -- a few
+/// microseconds for a decode step -- because catching the next job while still spinning is what
+/// keeps a dispatch sub-microsecond. Overshooting is not free: anything else runnable on the
+/// machine competes with the spinners, and on this codebase that is still the f32 matmul, which
+/// lives in the `gemm` crate and drives rayon itself.
+///
+/// While the f32 matmul still drove rayon this had to stay near 1000 to avoid the two pools
+/// fighting. With everything on one pool the tradeoff is gone and a longer bridge is uniformly
+/// better: measured across 3-8 threads and both vocoder windows, 5000 is at or above every
+/// other value tried, and roughly 20% better than 1000 at 8 threads.
+const DEFAULT_SPIN_BUDGET: u32 = 5_000;
+
+fn spin_budget() -> u32 {
+    static B: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+    *B.get_or_init(|| {
+        std::env::var("XN_SPIN_BUDGET")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_SPIN_BUDGET)
+    })
+}
+
+type Job = dyn Fn(usize, usize) + Sync;
+
+struct Shared {
+    /// Bumped once per published job; workers compare it against what they last ran.
+    seq: AtomicU64,
+    /// Borrowed for exactly as long as `seq` designates an unfinished job. The publisher blocks
+    /// until every participating worker has incremented `done`, which is the last thing they do
+    /// after their final read, so the reference cannot outlive the caller's frame.
+    job: std::cell::UnsafeCell<Option<*const Job>>,
+    /// Workers (excluding the publisher) that have finished the current job.
+    ///
+    /// *Every* worker acknowledges *every* job, even one whose share is empty. That is what
+    /// makes reading `job` safe: a worker latches `seq`, then reads the slot, and the publisher
+    /// cannot have moved on in between because it is still waiting for this worker's
+    /// acknowledgement. Letting some workers skip the count reintroduces that window, and a
+    /// lagging worker then runs the *next* job twice and double-counts it.
+    done: AtomicUsize,
+    /// Set if any worker panicked; the publisher re-raises so a panic is not silently swallowed.
+    panicked: AtomicBool,
+    quit: AtomicBool,
+    /// Park slot for workers whose spin budget ran out.
+    lock: Mutex<()>,
+    wake: Condvar,
+}
+
+// SAFETY: `job` is only read by workers between a `seq` bump (Release) and their `done` bump,
+// and only written by the publisher while no worker is inside that window.
+unsafe impl Sync for Shared {}
+unsafe impl Send for Shared {}
+
+struct Pool {
+    shared: &'static Shared,
+    /// Total participants including the publisher, i.e. `workers.len() + 1`.
+    size: usize,
+    /// There is one job slot, so one publisher at a time. Claimed for the whole dispatch.
+    ///
+    /// Contention means a second thread is already driving the pool -- another stream in the
+    /// same process, say. Waiting would be pointless: the cores are busy either way. So a
+    /// contended dispatch runs serially on its own thread instead of queueing.
+    ///
+    /// A plain flag rather than a `Mutex`, because a panic escaping a dispatch would poison a
+    /// mutex and silently demote every later dispatch to single-threaded. There is no data
+    /// under this lock to be left inconsistent, so poisoning has nothing to protect.
+    publish: AtomicBool,
+}
+
+thread_local! {
+    /// Set while this thread is running a pool job. Nested dispatches run serially rather than
+    /// deadlocking against a pool that is already fully occupied.
+    static IN_JOB: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+static POOL: OnceLock<Pool> = OnceLock::new();
+
+fn pool() -> &'static Pool {
+    POOL.get_or_init(|| {
+        let size = crate::get_num_threads().max(1);
+        let shared: &'static Shared = Box::leak(Box::new(Shared {
+            seq: AtomicU64::new(0),
+            job: std::cell::UnsafeCell::new(None),
+            done: AtomicUsize::new(0),
+            panicked: AtomicBool::new(false),
+            quit: AtomicBool::new(false),
+            lock: Mutex::new(()),
+            wake: Condvar::new(),
+        }));
+        for ith in 1..size {
+            std::thread::Builder::new()
+                .name(format!("xn-worker-{ith}"))
+                .spawn(move || worker(shared, ith, size))
+                .expect("spawning an xn worker thread");
+        }
+        Pool { shared, size, publish: AtomicBool::new(false) }
+    })
+}
+
+/// `nth` is fixed for the lifetime of the pool, so a worker never has to read it.
+fn worker(shared: &'static Shared, ith: usize, nth: usize) {
+    let mut last = 0u64;
+    loop {
+        // Spin first: between two operators of the same layer the next job usually lands within
+        // a few microseconds, and catching it here is what keeps dispatch cheap.
+        let mut seq = shared.seq.load(Ordering::Acquire);
+        let mut spins = 0u32;
+        while seq == last && !shared.quit.load(Ordering::Relaxed) {
+            if spins < spin_budget() {
+                spins += 1;
+                std::hint::spin_loop();
+            } else {
+                // The stream has gone quiet; give the core back.
+                let guard = shared.lock.lock().unwrap_or_else(|e| e.into_inner());
+                if shared.seq.load(Ordering::Acquire) == last
+                    && !shared.quit.load(Ordering::Relaxed)
+                {
+                    let _unused = shared.wake.wait(guard).unwrap_or_else(|e| e.into_inner());
+                }
+                spins = 0;
+            }
+            seq = shared.seq.load(Ordering::Acquire);
+        }
+        if shared.quit.load(Ordering::Relaxed) {
+            return;
+        }
+        last = seq;
+
+        // SAFETY: the publisher wrote `job` before the Release bump of `seq` we just acquired,
+        // and cannot publish another until this worker bumps `done` below.
+        let job = unsafe {
+            (*shared.job.get()).expect("a latched sequence number always has a job behind it")
+        };
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            IN_JOB.with(|f| f.set(true));
+            // SAFETY: same window as above; the publisher's frame outlives this call.
+            unsafe { (*job)(ith, nth) };
+        }));
+        IN_JOB.with(|f| f.set(false));
+        if result.is_err() {
+            shared.panicked.store(true, Ordering::Relaxed);
+        }
+        shared.done.fetch_add(1, Ordering::Release);
+    }
+}
+
+/// Whether to use the persistent pool. `XN_THREADPOOL=0` reverts to a rayon fork/join per
+/// operator, which is the escape hatch if the resident workers ever fight with something else
+/// for cores.
+fn enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| !matches!(std::env::var("XN_THREADPOOL").as_deref(), Ok("0")))
+}
+
+/// Holds the right to drive the pool, releasing it even if the dispatch unwinds.
+struct PublishGuard(&'static Pool);
+
+impl PublishGuard {
+    fn claim(pool: &'static Pool) -> Option<Self> {
+        // `then_some` would be wrong here: it builds its argument eagerly, so a *failed* claim
+        // would still construct a guard, and dropping it would release the token whichever
+        // other thread is currently holding -- two publishers, one job slot.
+        if pool.publish.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed).is_ok()
+        {
+            Some(Self(pool))
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for PublishGuard {
+    fn drop(&mut self) {
+        self.0.publish.store(false, Ordering::Release);
+    }
+}
+
+/// Threads this pool can put on one operator, including the calling thread.
+///
+/// Fixed at first use, like rayon's global pool: [`crate::set_num_threads`] after that point
+/// changes how work is chunked but cannot grow the pool.
+pub fn size() -> usize {
+    pool().size
+}
+
+/// Run `f(ith, nth)` on every participant and return once all of them have finished.
+///
+/// `nth` is always [`size`]; the caller is participant 0 and runs its share inline. Splitting
+/// the work is the callee's job, and a share that comes out empty is free -- that is cheaper
+/// than varying the participant count, which would let a lagging worker read a job that has
+/// already been replaced.
+///
+/// `f` must give each `ith` a disjoint slice of the output: the pool provides the barrier, not
+/// mutual exclusion.
+pub fn dispatch<F: Fn(usize, usize) + Sync>(f: F) {
+    if !enabled() {
+        // `XN_THREADPOOL=0`: fan out through rayon instead, the way this used to work.
+        let nth = rayon::current_num_threads().max(1);
+        use rayon::prelude::*;
+        (0..nth).into_par_iter().for_each(|ith| f(ith, nth));
+        return;
+    }
+    // A job that dispatches again would wait on workers already inside this job.
+    if IN_JOB.with(|f| f.get()) {
+        f(0, 1);
+        return;
+    }
+    let pool = pool();
+    let nth = pool.size;
+    if nth <= 1 {
+        f(0, 1);
+        return;
+    }
+    let Some(_publish) = PublishGuard::claim(pool) else {
+        // Another thread owns the pool; see the field's documentation.
+        f(0, 1);
+        return;
+    };
+    let shared = pool.shared;
+
+    let borrowed: &(dyn Fn(usize, usize) + Sync + '_) = &f;
+    // Erase the lifetime. Sound because this frame does not return until every worker has
+    // bumped `done`, which happens strictly after its last use of the reference.
+    let job: *const Job = unsafe {
+        std::mem::transmute::<*const (dyn Fn(usize, usize) + Sync + '_), *const Job>(borrowed)
+    };
+
+    // SAFETY: no worker can be reading `job` here -- the previous dispatch did not return until
+    // every worker had acknowledged it, and this one is not published yet.
+    unsafe { *shared.job.get() = Some(job) };
+    shared.done.store(0, Ordering::Relaxed);
+    shared.panicked.store(false, Ordering::Relaxed);
+    // Release: everything above is visible to any worker that observes the new sequence number.
+    shared.seq.fetch_add(1, Ordering::Release);
+    // Only costs anything if a worker actually parked.
+    {
+        let _guard = shared.lock.lock().unwrap_or_else(|e| e.into_inner());
+        shared.wake.notify_all();
+    }
+
+    let own = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(0, nth)));
+
+    let want = nth - 1;
+    let mut spins = 0u32;
+    while shared.done.load(Ordering::Acquire) < want {
+        if spins < spin_budget() {
+            spins += 1;
+            std::hint::spin_loop();
+        } else {
+            std::thread::yield_now();
+        }
+    }
+    // Clear before returning so a stale pointer is never observable.
+    // SAFETY: every worker has acknowledged; nobody is reading `job`.
+    unsafe { *shared.job.get() = None };
+
+    if let Err(payload) = own {
+        std::panic::resume_unwind(payload);
+    }
+    if shared.panicked.load(Ordering::Relaxed) {
+        panic!("an xn worker panicked while running a parallel operator");
+    }
+}
+
+/// Run `f(i)` for every `i` in `0..n`, handing indices out on demand.
+///
+/// The counterpart to [`dispatch`], which splits statically. A static split is only right when
+/// every participant runs at the same speed, and on a hybrid CPU it never does: an efficiency
+/// core takes several times longer over an equal share, and the barrier waits for it. That
+/// shows up as a long tail rather than a slow mean -- p95 and max frame times blow out while
+/// p50 barely moves. Pulling from a shared counter lets the fast cores absorb the difference,
+/// which is what ggml's `current_chunk` does for its own matmuls.
+///
+/// Indices are handed out in small consecutive runs so the atomic is touched a handful of
+/// times per worker rather than once per index, while still leaving enough runs to balance.
+pub fn par_units<F: Fn(usize) + Sync>(n: usize, f: F) {
+    if n == 0 {
+        return;
+    }
+    let nth = size();
+    if n == 1 || nth == 1 {
+        (0..n).for_each(&f);
+        return;
+    }
+    // Enough runs to rebalance (a straggler costs at most one run), few enough that the
+    // counter is not the bottleneck.
+    let runs = (nth * 8).min(n);
+    let batch = n.div_ceil(runs);
+    let next = AtomicUsize::new(0);
+    dispatch(|_, _| {
+        loop {
+            let start = next.fetch_add(batch, Ordering::Relaxed);
+            if start >= n {
+                break;
+            }
+            for i in start..(start + batch).min(n) {
+                f(i);
+            }
+        }
+    });
+}
+
+/// Split `dst` into `chunk`-sized pieces and run `f(index, piece)` on all of them.
+///
+/// The pool replacement for `dst.par_chunks_mut(chunk).enumerate().for_each(..)`. Each worker
+/// takes a contiguous run of pieces, so a worker's writes stay in one region.
+pub fn par_chunks_mut<T: Send + Sync, F>(dst: &mut [T], chunk: usize, f: F)
+where
+    F: Fn(usize, &mut [T]) + Sync,
+{
+    if chunk == 0 {
+        return;
+    }
+    let len = dst.len();
+    let nchunks = len.div_ceil(chunk);
+    if nchunks <= 1 || size() == 1 {
+        for (i, d) in dst.chunks_mut(chunk).enumerate() {
+            f(i, d);
+        }
+        return;
+    }
+    let base = dst.as_mut_ptr() as usize;
+    par_units(nchunks, |c| {
+        let start = c * chunk;
+        let end = ((c + 1) * chunk).min(len);
+        // SAFETY: each index is handed to exactly one worker, so the pieces do not overlap,
+        // and every piece lies inside the original slice.
+        let piece =
+            unsafe { std::slice::from_raw_parts_mut((base as *mut T).add(start), end - start) };
+        f(c, piece);
+    });
+}
+
+/// As [`par_chunks_mut`], but walking a read-only slice in step with the output.
+///
+/// The pool replacement for `src.par_chunks(chunk).zip(dst.par_chunks_mut(chunk)).for_each(..)`.
+/// `src` is chunked by `src_chunk`, which lets the two sides have different row widths.
+pub fn par_chunks_zip<T: Send + Sync, U: Sync, F>(
+    dst: &mut [T],
+    chunk: usize,
+    src: &[U],
+    src_chunk: usize,
+    f: F,
+) where
+    F: Fn(usize, &mut [T], &[U]) + Sync,
+{
+    if chunk == 0 {
+        return;
+    }
+    let len = dst.len();
+    let src_len = src.len();
+    let nchunks = len.div_ceil(chunk);
+    if nchunks <= 1 || size() == 1 {
+        for (i, d) in dst.chunks_mut(chunk).enumerate() {
+            let s = (i * src_chunk).min(src_len);
+            let e = ((i + 1) * src_chunk).min(src_len);
+            f(i, d, &src[s..e]);
+        }
+        return;
+    }
+    let base = dst.as_mut_ptr() as usize;
+    let sbase = src.as_ptr() as usize;
+    par_units(nchunks, |c| {
+        let start = c * chunk;
+        let end = ((c + 1) * chunk).min(len);
+        let sstart = (c * src_chunk).min(src_len);
+        let send = ((c + 1) * src_chunk).min(src_len);
+        // SAFETY: output pieces go to exactly one worker each and lie inside `dst`; the input
+        // pieces lie inside `src` and are only read.
+        let (piece, spiece) = unsafe {
+            (
+                std::slice::from_raw_parts_mut((base as *mut T).add(start), end - start),
+                std::slice::from_raw_parts((sbase as *const U).add(sstart), send - sstart),
+            )
+        };
+        f(c, piece, spiece);
+    });
+}
+
+/// Run `f(i)` for every `i` in `0..n`, split into contiguous runs across the pool.
+///
+/// The pool replacement for `(0..n).into_par_iter().for_each(..)`.
+pub fn par_range<F: Fn(usize) + Sync>(n: usize, f: F) {
+    if n <= 1 || size() == 1 {
+        (0..n).for_each(&f);
+        return;
+    }
+    par_units(n, f);
+}

--- a/xn-core/tests/threadpool_tests.rs
+++ b/xn-core/tests/threadpool_tests.rs
@@ -1,0 +1,136 @@
+//! The pool is a process-wide singleton with a single job slot, and a dispatch that finds it
+//! busy deliberately runs serially instead of queueing. Asserting on fan-out therefore only
+//! means anything when nothing else in the process is dispatching -- hence a dedicated test
+//! binary, and a mutex to keep these tests out of each other's way inside it.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+use xn::threadpool::{dispatch, size};
+
+static EXCLUSIVE: Mutex<()> = Mutex::new(());
+
+fn exclusive() -> std::sync::MutexGuard<'static, ()> {
+    EXCLUSIVE.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+#[test]
+fn every_participant_runs_exactly_once() {
+    let _x = exclusive();
+    // Repeat: a worker that lags into the *next* job would show up as a miscount, and only
+    // sometimes.
+    for round in 0..2000 {
+        let seen: Vec<AtomicU32> = (0..size()).map(|_| AtomicU32::new(0)).collect();
+        dispatch(|ith, n| {
+            assert_eq!(n, size());
+            seen[ith].fetch_add(1, Ordering::Relaxed);
+        });
+        for (i, c) in seen.iter().enumerate() {
+            assert_eq!(c.load(Ordering::Relaxed), 1, "round={round} ith={i}");
+        }
+    }
+}
+
+#[test]
+fn results_are_visible_to_the_caller() {
+    let _x = exclusive();
+    const N: usize = 4096;
+    for _ in 0..2000 {
+        let mut out = vec![0u64; N];
+        let ptr = out.as_mut_ptr() as usize;
+        dispatch(|ith, nth| {
+            let p = ptr as *mut u64;
+            let mut i = ith;
+            while i < N {
+                // SAFETY: stripes by `ith` are disjoint.
+                unsafe { *p.add(i) = (i as u64) + 1 };
+                i += nth;
+            }
+        });
+        assert!(out.iter().enumerate().all(|(i, v)| *v == i as u64 + 1));
+    }
+}
+
+#[test]
+fn nested_dispatch_runs_serially_instead_of_deadlocking() {
+    let _x = exclusive();
+    let inner = AtomicU32::new(0);
+    dispatch(|_, _| {
+        dispatch(|ith, nth| {
+            assert_eq!((ith, nth), (0, 1), "a nested dispatch must not fan out");
+            inner.fetch_add(1, Ordering::Relaxed);
+        });
+    });
+    assert_eq!(inner.load(Ordering::Relaxed), size() as u32);
+}
+
+#[test]
+fn a_worker_panic_reaches_the_caller() {
+    let _x = exclusive();
+    if size() < 2 {
+        return;
+    }
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let r = std::panic::catch_unwind(|| {
+        dispatch(|ith, _| {
+            if ith != 0 {
+                panic!("boom");
+            }
+        });
+    });
+    std::panic::set_hook(hook);
+    assert!(r.is_err(), "a panicking worker must not be swallowed");
+
+    // The pool must still be usable, and must not report the old panic again.
+    let n = AtomicU32::new(0);
+    dispatch(|_, _| {
+        n.fetch_add(1, Ordering::Relaxed);
+    });
+    assert_eq!(n.load(Ordering::Relaxed), size() as u32);
+}
+
+/// Several threads driving the pool at once.
+///
+/// Only one may publish; the rest fall back to running on their own thread. Getting that
+/// handover wrong does not deadlock -- it silently lets two publishers share one job slot, so
+/// workers run the wrong closure or skip their share, and the damage shows up as wrong numbers
+/// in whichever kernel happened to be running. This is the shape of test that catches it.
+#[test]
+fn concurrent_publishers_each_get_a_complete_result() {
+    // Contention is the point, but it comes from the threads spawned below -- the other tests
+    // in this file assert on fan-out and must not be caught in it.
+    let _x = exclusive();
+    const N: usize = 1024;
+    let threads = 4;
+    let bad = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let mut handles = Vec::new();
+    for t in 0..threads {
+        let bad = bad.clone();
+        handles.push(std::thread::spawn(move || {
+            for round in 0..4000 {
+                // A value unique to this thread and round, so a stripe written by someone
+                // else's job is detectable rather than coincidentally right.
+                let tag = ((t * 4000 + round) as u64) << 20;
+                let mut out = vec![0u64; N];
+                let ptr = out.as_mut_ptr() as usize;
+                dispatch(|ith, nth| {
+                    let p = ptr as *mut u64;
+                    let mut i = ith;
+                    while i < N {
+                        // SAFETY: stripes by `ith` are disjoint within this job, and each job
+                        // owns its own `out`.
+                        unsafe { *p.add(i) = tag | (i as u64) };
+                        i += nth;
+                    }
+                });
+                if out.iter().enumerate().any(|(i, v)| *v != tag | (i as u64)) {
+                    bad.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    assert_eq!(bad.load(Ordering::Relaxed), 0, "a concurrent dispatch produced a partial result");
+}


### PR DESCRIPTION
A 12-layer backbone issues ~50 quantized matmuls per token, each a few tens of microseconds. Handing every one to rayon costs a fork/join -- measured on an M5 at about 10 us with 3 workers and 34 us with 8 -- so dispatch grew faster than the work shrank and decode got *slower* past three threads.

ggml never dispatches per operator: it wakes its pool once per graph and the workers walk the node list together, meeting at a two-atomic spin barrier between nodes. xn is eager and has no graph to hand a pool, so this takes the other half of that idea: the workers are permanent and park only when the stream goes quiet, making a dispatch a sequence-number bump plus a spin.

Work is claimed from a shared counter rather than split evenly (`par_units`). An equal split is only right when participants run at the same speed, and on a 4P+6E machine they do not -- the barrier ends up waiting on an efficiency core, which shows up as a long tail rather than a slow mean. This is what ggml's `current_chunk` does.

Everything hot moved over together, which mattered more than any single conversion: with the f32 matmul still driving rayon, two pools' idle workers spun against each other and the gains cancelled. `gemm` offers no hook for a foreign pool, so it is called per column stripe with `Parallelism::None`; the stripe count was swept and one per participant is optimal.

Measured on an M5, 12x768 backbone, q8 gemm time per token, best of 3:

    threads          2      3      4      6      8
    before       2.485  2.451  2.599  2.877  2.740 ms
    after        2.036  1.758  1.648  1.337  1.266 ms
    speedup       1.22x  1.39x  1.58x  2.15x  2.17x

It now scales with threads instead of regressing past three. End to end on a TTS decode loop, 11.4x -> 15.0x realtime with a windowed vocoder.

Output is unchanged bit for bit at any given thread count.

`XN_THREADPOOL=0` reverts to the rayon fan-out; `XN_SPIN_BUDGET` tunes how long a worker spins before parking.